### PR TITLE
FE parity PAR-151 - Android agent orchestration/fleet/workers

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorDataModule.kt
@@ -1,0 +1,21 @@
+package com.testlogon.android.feature.agents.orchestrator.data
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - Hilt wiring for the ORCHESTRATOR feature. Binds the repository seam to its
+ * impl (the transport [com.testlogon.android.core.network.agents.OrchestratorApi] is provided by
+ * AgentsNetworkModule alongside the other agents APIs).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class OrchestratorDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindOrchestratorRepository(impl: DefaultOrchestratorRepository): OrchestratorRepository
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorDomain.kt
@@ -1,0 +1,101 @@
+package com.testlogon.android.feature.agents.orchestrator.data
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - framework-free domain for the agent-loop ORCHESTRATOR console (mobile
+ * mirror of the web agent-orchestrator control surface). One console drives a single worker's loop lifecycle:
+ * start/pause/resume/stop + manual claim/complete/release + heartbeat + eligible-ticket preview.
+ *
+ * The domain is deliberately pure (no Android / coroutine / Retrofit deps) so [OrchestratorMath] is
+ * JVM-unit-testable.
+ */
+
+/**
+ * The agent loop state, mirroring backend agent_state values ("idle"/"working"/"paused"/"stopped"). [UNKNOWN]
+ * covers any value the server introduces later so the console degrades rather than crashes.
+ */
+enum class AgentLoopState(val wire: String, val label: String) {
+    IDLE("idle", "Idle"),
+    WORKING("working", "Working"),
+    PAUSED("paused", "Paused"),
+    STOPPED("stopped", "Stopped"),
+    UNKNOWN("", "Unknown");
+
+    companion object {
+        fun from(raw: String?): AgentLoopState =
+            entries.firstOrNull { it.wire.isNotEmpty() && it.wire.equals(raw?.trim(), ignoreCase = true) }
+                ?: UNKNOWN
+    }
+}
+
+/** The finite set of loop-control actions the console can offer. */
+enum class LoopAction {
+    START, PAUSE, RESUME, STOP, CLAIM, COMPLETE, RELEASE, HEARTBEAT,
+}
+
+/** The worker's ticket-filter config (round-trips status GET <-> ticket-filter PUT). */
+data class TicketFilter(
+    val types: List<String> = emptyList(),
+    val tags: List<String> = emptyList(),
+    val spaceIds: List<String> = emptyList(),
+    val priorities: List<String> = emptyList(),
+) {
+    val isEmpty: Boolean
+        get() = types.isEmpty() && tags.isEmpty() && spaceIds.isEmpty() && priorities.isEmpty()
+}
+
+/** The orchestrator status snapshot for one worker (GET .../status). */
+data class AgentStatus(
+    val workerId: String,
+    val state: AgentLoopState,
+    val currentTicketId: String,
+    val currentTicketTitle: String,
+    val ticketsCompleted: Int,
+    val ticketsFailed: Int,
+    val heartbeatAt: Long,
+    val lastActivityAt: Long,
+    val ticketFilter: TicketFilter,
+    val loopRunning: Boolean,
+) {
+    /** True when a ticket is currently claimed to this worker. */
+    val hasActiveTicket: Boolean get() = currentTicketId.isNotBlank()
+}
+
+/** One ticket the loop is eligible to pick up (GET .../eligible-tickets). */
+data class EligibleTicket(
+    val ticketId: String,
+    val title: String,
+    val priority: String,
+    val type: String,
+    val tags: List<String>,
+    val spaceId: String,
+    val createdAt: Long,
+)
+
+/** The eligible-tickets preview with its applied filter. */
+data class EligibleTickets(
+    val tickets: List<EligibleTicket>,
+    val count: Int,
+    val filterApplied: TicketFilter?,
+)
+
+/** Result of a loop-control action (start/pause/resume/stop). */
+data class LoopActionResult(
+    val ok: Boolean,
+    val workerId: String,
+    val agentState: AgentLoopState,
+    val message: String,
+)
+
+/** Result of a ticket op (release/complete). */
+data class TicketOpResult(
+    val ok: Boolean,
+    val workerId: String,
+    val ticketId: String,
+    val agentState: AgentLoopState,
+)
+
+/** Result of a manual heartbeat. */
+data class HeartbeatResult(
+    val ok: Boolean,
+    val heartbeatAt: Long,
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorMappers.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorMappers.kt
@@ -1,0 +1,71 @@
+package com.testlogon.android.feature.agents.orchestrator.data
+
+import com.testlogon.android.core.network.agents.AgentStatusDto
+import com.testlogon.android.core.network.agents.CompleteTicketResultDto
+import com.testlogon.android.core.network.agents.EligibleTicketDto
+import com.testlogon.android.core.network.agents.EligibleTicketsDto
+import com.testlogon.android.core.network.agents.HeartbeatResultDto
+import com.testlogon.android.core.network.agents.LoopActionResultDto
+import com.testlogon.android.core.network.agents.ReleaseTicketResultDto
+import com.testlogon.android.core.network.agents.TicketFilterConfigDto
+
+/** AGENT-ORCHESTRATOR (web-parity) - DTO <-> domain mappers for the ORCHESTRATOR surface. */
+
+fun TicketFilterConfigDto?.toDomain(): TicketFilter =
+    if (this == null) TicketFilter()
+    else TicketFilter(types = types, tags = tags, spaceIds = spaceIds, priorities = priorities)
+
+fun TicketFilter.toDto(): TicketFilterConfigDto =
+    TicketFilterConfigDto(types = types, tags = tags, spaceIds = spaceIds, priorities = priorities)
+
+fun AgentStatusDto.toDomain(): AgentStatus = AgentStatus(
+    workerId = workerId,
+    state = AgentLoopState.from(agentState),
+    currentTicketId = currentTicketId,
+    currentTicketTitle = currentTicketTitle,
+    ticketsCompleted = ticketsCompleted,
+    ticketsFailed = ticketsFailed,
+    heartbeatAt = heartbeatAt,
+    lastActivityAt = lastActivityAt,
+    ticketFilter = ticketFilter.toDomain(),
+    loopRunning = loopRunning,
+)
+
+fun LoopActionResultDto.toDomain(): LoopActionResult = LoopActionResult(
+    ok = ok,
+    workerId = workerId,
+    agentState = AgentLoopState.from(agentState),
+    message = message,
+)
+
+fun ReleaseTicketResultDto.toDomain(): TicketOpResult = TicketOpResult(
+    ok = ok,
+    workerId = workerId,
+    ticketId = releasedTicketId,
+    agentState = AgentLoopState.from(agentState),
+)
+
+fun CompleteTicketResultDto.toDomain(): TicketOpResult = TicketOpResult(
+    ok = ok,
+    workerId = workerId,
+    ticketId = completedTicketId,
+    agentState = AgentLoopState.from(agentState),
+)
+
+fun HeartbeatResultDto.toDomain(): HeartbeatResult = HeartbeatResult(ok = ok, heartbeatAt = heartbeatAt)
+
+fun EligibleTicketDto.toDomain(): EligibleTicket = EligibleTicket(
+    ticketId = ticketId,
+    title = title,
+    priority = priority,
+    type = type,
+    tags = tags,
+    spaceId = spaceId,
+    createdAt = createdAt,
+)
+
+fun EligibleTicketsDto.toDomain(): EligibleTickets = EligibleTickets(
+    tickets = tickets.map { it.toDomain() },
+    count = count,
+    filterApplied = filterApplied?.toDomain(),
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorMath.kt
@@ -1,0 +1,119 @@
+package com.testlogon.android.feature.agents.orchestrator.data
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - PURE loop-lifecycle logic for the orchestrator console. No Android /
+ * coroutine / Retrofit deps -> fully JVM-unit-testable. Mirrors the guard rules the backend
+ * app/routers/agent_orchestrator.py enforces, so the console never offers an action the server would reject:
+ *
+ *  - START     : only when the loop is NOT already running (idle/stopped/unknown). 409 loop_already_running.
+ *  - PAUSE     : only when the loop IS running. (finish current work, don't pick new)
+ *  - RESUME    : only when paused.
+ *  - STOP      : whenever the loop is running or paused (graceful).
+ *  - CLAIM     : only when NO active ticket (409 worker_busy otherwise).
+ *  - COMPLETE  : only when there IS an active ticket (400 no_active_ticket otherwise).
+ *  - RELEASE   : only when there IS an active ticket.
+ *  - HEARTBEAT : always available (debug ping).
+ *
+ * These are UI-affordance guards, not a re-implementation of server truth: the server remains the source of
+ * truth (a rejected action still surfaces its error).
+ */
+object OrchestratorMath {
+
+    /** The set of loop-control + ticket actions that are currently valid for [status]. */
+    fun availableActions(status: AgentStatus): Set<LoopAction> {
+        val actions = linkedSetOf<LoopAction>()
+        val running = status.loopRunning
+        when (status.state) {
+            AgentLoopState.PAUSED -> {
+                actions += LoopAction.RESUME
+                actions += LoopAction.STOP
+            }
+            AgentLoopState.WORKING -> {
+                actions += LoopAction.PAUSE
+                actions += LoopAction.STOP
+            }
+            AgentLoopState.IDLE, AgentLoopState.STOPPED, AgentLoopState.UNKNOWN -> {
+                if (running) {
+                    actions += LoopAction.PAUSE
+                    actions += LoopAction.STOP
+                } else {
+                    actions += LoopAction.START
+                }
+            }
+        }
+        // Ticket operations gate purely on whether a ticket is claimed.
+        if (status.hasActiveTicket) {
+            actions += LoopAction.COMPLETE
+            actions += LoopAction.RELEASE
+        } else {
+            actions += LoopAction.CLAIM
+        }
+        actions += LoopAction.HEARTBEAT
+        return actions
+    }
+
+    fun canStart(status: AgentStatus): Boolean = LoopAction.START in availableActions(status)
+    fun canPause(status: AgentStatus): Boolean = LoopAction.PAUSE in availableActions(status)
+    fun canResume(status: AgentStatus): Boolean = LoopAction.RESUME in availableActions(status)
+    fun canStop(status: AgentStatus): Boolean = LoopAction.STOP in availableActions(status)
+    fun canClaim(status: AgentStatus): Boolean = LoopAction.CLAIM in availableActions(status)
+    fun canComplete(status: AgentStatus): Boolean = LoopAction.COMPLETE in availableActions(status)
+    fun canRelease(status: AgentStatus): Boolean = LoopAction.RELEASE in availableActions(status)
+
+    /**
+     * Optimistic local projection of what [status] becomes after [action] succeeds. Used to keep the console
+     * responsive before the follow-up status refetch lands (and, for CLAIM, to seed the claimed ticket id). The
+     * server refetch always overwrites this, so it only needs to be plausible, not authoritative.
+     */
+    fun project(status: AgentStatus, action: LoopAction, claimedTicketId: String = ""): AgentStatus =
+        when (action) {
+            LoopAction.START -> status.copy(state = AgentLoopState.WORKING, loopRunning = true)
+            LoopAction.RESUME -> status.copy(state = AgentLoopState.IDLE, loopRunning = true)
+            LoopAction.PAUSE -> status.copy(state = AgentLoopState.PAUSED)
+            LoopAction.STOP -> status.copy(state = AgentLoopState.STOPPED, loopRunning = false)
+            LoopAction.CLAIM -> status.copy(currentTicketId = claimedTicketId)
+            LoopAction.RELEASE -> status.copy(
+                currentTicketId = "",
+                currentTicketTitle = "",
+                state = AgentLoopState.IDLE,
+            )
+            LoopAction.COMPLETE -> status.copy(
+                currentTicketId = "",
+                currentTicketTitle = "",
+                state = AgentLoopState.IDLE,
+                ticketsCompleted = status.ticketsCompleted + 1,
+            )
+            LoopAction.HEARTBEAT -> status
+        }
+
+    /**
+     * Seconds since the last heartbeat given [nowSeconds]; null when never beaten or when the clock is behind
+     * the recorded beat (do not surface a negative age).
+     */
+    fun heartbeatAgeSeconds(status: AgentStatus, nowSeconds: Long): Long? {
+        if (status.heartbeatAt <= 0) return null
+        val age = nowSeconds - status.heartbeatAt
+        return if (age < 0) null else age
+    }
+
+    /**
+     * True when the loop is running but the last heartbeat is older than [staleThresholdSeconds] - the console
+     * badges the worker as "may be stalled". A stopped/never-beaten worker is never "stale".
+     */
+    fun isHeartbeatStale(status: AgentStatus, nowSeconds: Long, staleThresholdSeconds: Long): Boolean {
+        if (!status.loopRunning) return false
+        val age = heartbeatAgeSeconds(status, nowSeconds) ?: return false
+        return age > staleThresholdSeconds
+    }
+
+    /** A short, human summary line for the status header. */
+    fun summaryLine(status: AgentStatus): String {
+        val running = if (status.loopRunning) "loop running" else "loop stopped"
+        val ticket = if (status.hasActiveTicket) {
+            "on ${status.currentTicketTitle.ifBlank { status.currentTicketId }}"
+        } else {
+            "no active ticket"
+        }
+        return "${status.state.label} · $running · $ticket"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorRepository.kt
@@ -1,0 +1,135 @@
+package com.testlogon.android.feature.agents.orchestrator.data
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.network.agents.ClaimTicketRequest
+import com.testlogon.android.core.network.agents.CompleteTicketRequest
+import com.testlogon.android.core.network.agents.OrchestratorApi
+import com.testlogon.android.core.network.error.ApiErrorParser
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - data layer for the agent-loop ORCHESTRATOR over [OrchestratorApi]. Folds
+ * transport into [ApiResult] via [call] (HTTP -> Failure preserving status; malformed JSON -> Failure; transport
+ * -> NetworkError; cancellation re-thrown) - matching the AGENTS-BASICS repository fold.
+ *
+ * DEGRADE-ON-404: [eligibleTickets] and [status] surface a 404 as ApiResult.Success(null) so the console shows
+ * "worker not orchestratable / nothing yet" rather than a hard error (the worker may exist in the workers list
+ * but have no orchestrator record). All mutations preserve their 4xx (409 busy / already-running etc.) so the
+ * ViewModel can message the conflict.
+ */
+interface OrchestratorRepository {
+    /** DEGRADE-ON-404: a 404 (no orchestrator record) becomes Success(null). */
+    suspend fun status(workerId: String): ApiResult<AgentStatus?>
+    suspend fun start(workerId: String): ApiResult<LoopActionResult>
+    suspend fun pause(workerId: String): ApiResult<LoopActionResult>
+    suspend fun resume(workerId: String): ApiResult<LoopActionResult>
+    suspend fun stop(workerId: String): ApiResult<LoopActionResult>
+    suspend fun claim(workerId: String, ticketId: String): ApiResult<Unit>
+    suspend fun complete(workerId: String, summary: String?, prUrl: String?): ApiResult<TicketOpResult>
+    suspend fun release(workerId: String): ApiResult<TicketOpResult>
+    suspend fun heartbeat(workerId: String): ApiResult<HeartbeatResult>
+    /** DEGRADE-ON-404: a 404 becomes Success(null). */
+    suspend fun eligibleTickets(workerId: String): ApiResult<EligibleTickets?>
+    suspend fun updateTicketFilter(workerId: String, filter: TicketFilter): ApiResult<Unit>
+}
+
+@Singleton
+class DefaultOrchestratorRepository @Inject constructor(
+    private val api: OrchestratorApi,
+    private val errorParser: ApiErrorParser,
+) : OrchestratorRepository {
+
+    override suspend fun status(workerId: String): ApiResult<AgentStatus?> =
+        withContext(Dispatchers.IO) { callDegradable { api.status(workerId).toDomain() } }
+
+    override suspend fun start(workerId: String): ApiResult<LoopActionResult> =
+        withContext(Dispatchers.IO) { call { api.start(workerId).toDomain() } }
+
+    override suspend fun pause(workerId: String): ApiResult<LoopActionResult> =
+        withContext(Dispatchers.IO) { call { api.pause(workerId).toDomain() } }
+
+    override suspend fun resume(workerId: String): ApiResult<LoopActionResult> =
+        withContext(Dispatchers.IO) { call { api.resume(workerId).toDomain() } }
+
+    override suspend fun stop(workerId: String): ApiResult<LoopActionResult> =
+        withContext(Dispatchers.IO) { call { api.stop(workerId).toDomain() } }
+
+    override suspend fun claim(workerId: String, ticketId: String): ApiResult<Unit> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.claimTicket(workerId, ClaimTicketRequest(ticketId = ticketId))
+                Unit
+            }
+        }
+
+    override suspend fun complete(
+        workerId: String,
+        summary: String?,
+        prUrl: String?,
+    ): ApiResult<TicketOpResult> = withContext(Dispatchers.IO) {
+        call {
+            api.completeTicket(
+                workerId,
+                CompleteTicketRequest(
+                    summary = summary?.takeIf { it.isNotBlank() },
+                    prUrl = prUrl?.takeIf { it.isNotBlank() },
+                ),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun release(workerId: String): ApiResult<TicketOpResult> =
+        withContext(Dispatchers.IO) { call { api.releaseTicket(workerId).toDomain() } }
+
+    override suspend fun heartbeat(workerId: String): ApiResult<HeartbeatResult> =
+        withContext(Dispatchers.IO) { call { api.heartbeat(workerId).toDomain() } }
+
+    override suspend fun eligibleTickets(workerId: String): ApiResult<EligibleTickets?> =
+        withContext(Dispatchers.IO) { callDegradable { api.eligibleTickets(workerId).toDomain() } }
+
+    override suspend fun updateTicketFilter(workerId: String, filter: TicketFilter): ApiResult<Unit> =
+        withContext(Dispatchers.IO) {
+            call {
+                api.updateTicketFilter(workerId, filter.toDto())
+                Unit
+            }
+        }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+
+    /** Like [call] but a 404 becomes Success(null) (degrade-on-404). */
+    private suspend fun <T> callDegradable(block: suspend () -> T): ApiResult<T?> = try {
+        ApiResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpException) {
+        if (e.code() == 404) ApiResult.Success(null) else ApiResult.Failure(errorParser.from(e))
+    } catch (e: JsonEncodingException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: JsonDataException) {
+        ApiResult.Failure(errorParser.fromThrowable(e))
+    } catch (e: IOException) {
+        ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/ui/OrchestratorScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/ui/OrchestratorScreen.kt
@@ -1,0 +1,317 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.agents.orchestrator.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.feature.agents.orchestrator.data.AgentStatus
+import com.testlogon.android.feature.agents.orchestrator.data.EligibleTicket
+import com.testlogon.android.feature.agents.orchestrator.data.LoopAction
+
+/** AGENT-ORCHESTRATOR - stable testTags for the orchestrator console. */
+object OrchestratorTestTags {
+    const val SCREEN = "orchestrator_screen"
+    const val START = "orchestrator_start"
+    const val PAUSE = "orchestrator_pause"
+    const val RESUME = "orchestrator_resume"
+    const val STOP = "orchestrator_stop"
+    const val COMPLETE = "orchestrator_complete"
+    const val RELEASE = "orchestrator_release"
+    const val HEARTBEAT = "orchestrator_heartbeat"
+}
+
+@Composable
+fun OrchestratorRoute(
+    onBack: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    viewModel: OrchestratorViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is OrchestratorEffect.NavigateToLogin -> onNavigateToLogin()
+            }
+        }
+    }
+    OrchestratorScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::load,
+        onStart = viewModel::start,
+        onPause = viewModel::pause,
+        onResume = viewModel::resume,
+        onStop = viewModel::stop,
+        onRelease = viewModel::release,
+        onHeartbeat = viewModel::heartbeat,
+        onComplete = { viewModel.complete(null, null) },
+        onClaim = viewModel::claim,
+        onReloadEligible = viewModel::loadEligible,
+    )
+}
+
+@Composable
+fun OrchestratorScreen(
+    state: OrchestratorUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onStop: () -> Unit,
+    onRelease: () -> Unit,
+    onHeartbeat: () -> Unit,
+    onComplete: () -> Unit,
+    onClaim: (String) -> Unit,
+    onReloadEligible: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(OrchestratorTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Agent loop") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state) {
+            is OrchestratorUiState.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            is OrchestratorUiState.NoLoop ->
+                EmptyState(
+                    modifier = Modifier.padding(padding),
+                    title = "No agent loop",
+                    body = "This worker has no orchestrator record yet. Start the worker, then retry.",
+                    actionLabel = "Retry",
+                    onAction = onRetry,
+                )
+            is OrchestratorUiState.Error ->
+                ErrorState(modifier = Modifier.padding(padding), message = state.message, onRetry = onRetry)
+            is OrchestratorUiState.Content ->
+                OrchestratorContent(
+                    modifier = Modifier.padding(padding),
+                    state = state,
+                    onStart = onStart,
+                    onPause = onPause,
+                    onResume = onResume,
+                    onStop = onStop,
+                    onRelease = onRelease,
+                    onHeartbeat = onHeartbeat,
+                    onComplete = onComplete,
+                    onClaim = onClaim,
+                    onReloadEligible = onReloadEligible,
+                )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun OrchestratorContent(
+    state: OrchestratorUiState.Content,
+    onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onStop: () -> Unit,
+    onRelease: () -> Unit,
+    onHeartbeat: () -> Unit,
+    onComplete: () -> Unit,
+    onClaim: (String) -> Unit,
+    onReloadEligible: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val status = state.status
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            status.workerId.ifBlank { "Worker" },
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Text(state.summary, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+        StatusCard(status)
+
+        state.notice?.let {
+            Text(it, color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
+        }
+        state.actionError?.let {
+            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+
+        if (state.actioning != null) {
+            CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.padding(8.dp))
+        } else {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (LoopAction.START in state.actions) {
+                    Button(onClick = onStart, modifier = Modifier.testTag(OrchestratorTestTags.START)) { Text("Start") }
+                }
+                if (LoopAction.RESUME in state.actions) {
+                    Button(onClick = onResume, modifier = Modifier.testTag(OrchestratorTestTags.RESUME)) { Text("Resume") }
+                }
+                if (LoopAction.PAUSE in state.actions) {
+                    OutlinedButton(onClick = onPause, modifier = Modifier.testTag(OrchestratorTestTags.PAUSE)) { Text("Pause") }
+                }
+                if (LoopAction.STOP in state.actions) {
+                    OutlinedButton(
+                        onClick = onStop,
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                        modifier = Modifier.testTag(OrchestratorTestTags.STOP),
+                    ) { Text("Stop") }
+                }
+                if (LoopAction.HEARTBEAT in state.actions) {
+                    TextButton(onClick = onHeartbeat, modifier = Modifier.testTag(OrchestratorTestTags.HEARTBEAT)) { Text("Heartbeat") }
+                }
+            }
+        }
+
+        HorizontalDivider()
+
+        // ---- Active-ticket controls ----
+        Text("Current ticket", style = MaterialTheme.typography.titleMedium)
+        if (status.hasActiveTicket) {
+            Card(Modifier.fillMaxWidth()) {
+                Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(status.currentTicketTitle.ifBlank { status.currentTicketId }, style = MaterialTheme.typography.bodyLarge)
+                    if (status.currentTicketTitle.isNotBlank()) {
+                        Text(status.currentTicketId, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace)
+                    }
+                    if (state.actioning == null) {
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            if (LoopAction.COMPLETE in state.actions) {
+                                Button(onClick = onComplete, modifier = Modifier.testTag(OrchestratorTestTags.COMPLETE)) { Text("Complete") }
+                            }
+                            if (LoopAction.RELEASE in state.actions) {
+                                OutlinedButton(onClick = onRelease, modifier = Modifier.testTag(OrchestratorTestTags.RELEASE)) { Text("Release") }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            Text(
+                "No ticket claimed. Pick one from the eligible queue below.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        HorizontalDivider()
+
+        // ---- Eligible tickets ----
+        Text("Eligible tickets", style = MaterialTheme.typography.titleMedium)
+        when {
+            state.eligibleLoading -> CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.padding(8.dp))
+            state.eligible.isEmpty() ->
+                Text(
+                    "No eligible tickets right now.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            else -> state.eligible.forEach { ticket ->
+                EligibleTicketRow(
+                    ticket = ticket,
+                    canClaim = LoopAction.CLAIM in state.actions && state.actioning == null,
+                    onClaim = { onClaim(ticket.ticketId) },
+                )
+            }
+        }
+        TextButton(onClick = onReloadEligible) { Text("Refresh eligible") }
+    }
+}
+
+@Composable
+private fun StatusCard(status: AgentStatus) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Field("State", status.state.label)
+            Field("Loop", if (status.loopRunning) "running" else "stopped")
+            Field("Completed", status.ticketsCompleted.toString())
+            Field("Failed", status.ticketsFailed.toString())
+            if (!status.ticketFilter.isEmpty) {
+                val f = status.ticketFilter
+                val parts = buildList {
+                    if (f.types.isNotEmpty()) add("types=${f.types.joinToString(",")}")
+                    if (f.priorities.isNotEmpty()) add("prio=${f.priorities.joinToString(",")}")
+                    if (f.tags.isNotEmpty()) add("tags=${f.tags.joinToString(",")}")
+                }
+                Field("Filter", parts.joinToString(" · "))
+            }
+        }
+    }
+}
+
+@Composable
+private fun EligibleTicketRow(
+    ticket: EligibleTicket,
+    canClaim: Boolean,
+    onClaim: () -> Unit,
+) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(ticket.title.ifBlank { ticket.ticketId }, style = MaterialTheme.typography.bodyLarge)
+            val meta = listOf(ticket.type, ticket.priority).filter { it.isNotBlank() }.joinToString(" · ")
+            if (meta.isNotBlank()) {
+                Text(meta, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (canClaim) {
+                Button(onClick = onClaim) { Text("Claim") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Field(label: String, value: String) {
+    if (value.isBlank()) return
+    androidx.compose.foundation.layout.Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(0.4f))
+        Text(value, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(0.6f))
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/ui/OrchestratorUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/ui/OrchestratorUiState.kt
@@ -1,0 +1,40 @@
+package com.testlogon.android.feature.agents.orchestrator.ui
+
+import com.testlogon.android.feature.agents.orchestrator.data.AgentStatus
+import com.testlogon.android.feature.agents.orchestrator.data.EligibleTicket
+import com.testlogon.android.feature.agents.orchestrator.data.LoopAction
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - UI state + one-shot effects for the orchestrator console.
+ */
+sealed interface OrchestratorUiState {
+    data object Loading : OrchestratorUiState
+
+    /**
+     * The worker exists but has no orchestrator record yet (status 404, degrade-on-404). The console offers a
+     * retry (the loop can still be reached once the worker record is orchestratable).
+     */
+    data object NoLoop : OrchestratorUiState
+
+    data class Content(
+        val status: AgentStatus,
+        /** The set of loop actions currently offered (derived from [status] via OrchestratorMath). */
+        val actions: Set<LoopAction>,
+        val summary: String,
+        val eligible: List<EligibleTicket> = emptyList(),
+        val eligibleLoading: Boolean = false,
+        val isRefreshing: Boolean = false,
+        /** The action currently in flight (disables the button row); null when idle. */
+        val actioning: LoopAction? = null,
+        val actionError: String? = null,
+        /** Transient success banner (e.g. "Heartbeat sent"); cleared on the next action. */
+        val notice: String? = null,
+    ) : OrchestratorUiState
+
+    data class Error(val message: String) : OrchestratorUiState
+}
+
+/** One-shot effects. */
+sealed interface OrchestratorEffect {
+    data object NavigateToLogin : OrchestratorEffect
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/ui/OrchestratorViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/orchestrator/ui/OrchestratorViewModel.kt
@@ -1,0 +1,181 @@
+package com.testlogon.android.feature.agents.orchestrator.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.feature.agents.orchestrator.data.AgentStatus
+import com.testlogon.android.feature.agents.orchestrator.data.LoopAction
+import com.testlogon.android.feature.agents.orchestrator.data.OrchestratorMath
+import com.testlogon.android.feature.agents.orchestrator.data.OrchestratorRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - drives the orchestrator console for ONE worker. Loads status (+ eligible
+ * ticket preview), derives the available loop actions via [OrchestratorMath], and dispatches loop-control /
+ * ticket ops, re-fetching status on success. Degrade-on-404 (no orchestrator record) surfaces as
+ * [OrchestratorUiState.NoLoop]; a 401 hands off to login.
+ */
+@HiltViewModel
+class OrchestratorViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val repo: OrchestratorRepository,
+) : ViewModel() {
+
+    private val workerId: String = savedStateHandle.get<String>(ARG_WORKER_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow<OrchestratorUiState>(OrchestratorUiState.Loading)
+    val uiState: StateFlow<OrchestratorUiState> = _uiState.asStateFlow()
+
+    private val _effects = Channel<OrchestratorEffect>(Channel.BUFFERED)
+    val effects: Flow<OrchestratorEffect> = _effects.receiveAsFlow()
+
+    init { load() }
+
+    fun load() {
+        _uiState.value = OrchestratorUiState.Loading
+        fetchStatus(thenEligible = true)
+    }
+
+    fun refresh() {
+        (_uiState.value as? OrchestratorUiState.Content)?.let {
+            _uiState.value = it.copy(isRefreshing = true)
+        }
+        fetchStatus(thenEligible = true)
+    }
+
+    private fun fetchStatus(thenEligible: Boolean) {
+        viewModelScope.launch {
+            when (val result = repo.status(workerId)) {
+                is ApiResult.Success -> {
+                    val status = result.data
+                    if (status == null) {
+                        _uiState.value = OrchestratorUiState.NoLoop
+                    } else {
+                        renderStatus(status)
+                        if (thenEligible) fetchEligible()
+                    }
+                }
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(OrchestratorEffect.NavigateToLogin)
+                    _uiState.value = OrchestratorUiState.Error(result.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.value = OrchestratorUiState.Error(OFFLINE)
+            }
+        }
+    }
+
+    private fun renderStatus(status: AgentStatus, notice: String? = null) {
+        val previous = _uiState.value as? OrchestratorUiState.Content
+        _uiState.value = OrchestratorUiState.Content(
+            status = status,
+            actions = OrchestratorMath.availableActions(status),
+            summary = OrchestratorMath.summaryLine(status),
+            eligible = previous?.eligible.orEmpty(),
+            eligibleLoading = previous?.eligibleLoading ?: false,
+            isRefreshing = false,
+            actioning = null,
+            actionError = null,
+            notice = notice,
+        )
+    }
+
+    fun loadEligible() = fetchEligible()
+
+    private fun fetchEligible() {
+        val current = _uiState.value as? OrchestratorUiState.Content ?: return
+        _uiState.value = current.copy(eligibleLoading = true)
+        viewModelScope.launch {
+            when (val result = repo.eligibleTickets(workerId)) {
+                is ApiResult.Success -> {
+                    val latest = _uiState.value as? OrchestratorUiState.Content ?: return@launch
+                    _uiState.value = latest.copy(
+                        eligible = result.data?.tickets.orEmpty(),
+                        eligibleLoading = false,
+                    )
+                }
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(OrchestratorEffect.NavigateToLogin)
+                    val latest = _uiState.value as? OrchestratorUiState.Content ?: return@launch
+                    _uiState.value = latest.copy(eligibleLoading = false)
+                }
+                is ApiResult.NetworkError -> {
+                    val latest = _uiState.value as? OrchestratorUiState.Content ?: return@launch
+                    _uiState.value = latest.copy(eligibleLoading = false)
+                }
+            }
+        }
+    }
+
+    fun start() = act(LoopAction.START) { repo.start(workerId) }
+    fun pause() = act(LoopAction.PAUSE) { repo.pause(workerId) }
+    fun resume() = act(LoopAction.RESUME) { repo.resume(workerId) }
+    fun stop() = act(LoopAction.STOP) { repo.stop(workerId) }
+    fun release() = act(LoopAction.RELEASE) { repo.release(workerId) }
+    fun heartbeat() = act(LoopAction.HEARTBEAT, notice = "Heartbeat sent.") { repo.heartbeat(workerId) }
+
+    fun claim(ticketId: String) {
+        if (ticketId.isBlank()) return
+        act(LoopAction.CLAIM) { repo.claim(workerId, ticketId) }
+    }
+
+    fun complete(summary: String?, prUrl: String?) =
+        act(LoopAction.COMPLETE) { repo.complete(workerId, summary, prUrl) }
+
+    /**
+     * Runs a loop/ticket mutation, then re-fetches status (source of truth). On success a [notice] can be shown;
+     * a 401 hands off to login; other failures set actionError without leaving the Content state.
+     */
+    private fun act(action: LoopAction, notice: String? = null, block: suspend () -> ApiResult<*>) {
+        val current = _uiState.value as? OrchestratorUiState.Content ?: return
+        if (current.actioning != null) return
+        _uiState.value = current.copy(actioning = action, actionError = null, notice = null)
+        viewModelScope.launch {
+            when (val result = block()) {
+                is ApiResult.Success -> refetchStatusAfterAction(notice)
+                is ApiResult.Failure -> {
+                    if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(OrchestratorEffect.NavigateToLogin)
+                    clearActioning(result.error.message)
+                }
+                is ApiResult.NetworkError -> clearActioning(OFFLINE)
+            }
+        }
+    }
+
+    private suspend fun refetchStatusAfterAction(notice: String?) {
+        when (val result = repo.status(workerId)) {
+            is ApiResult.Success -> {
+                val status = result.data
+                if (status == null) _uiState.value = OrchestratorUiState.NoLoop
+                else {
+                    renderStatus(status, notice = notice)
+                    fetchEligible()
+                }
+            }
+            is ApiResult.Failure -> {
+                if (result.error.status == HTTP_UNAUTHORIZED) _effects.send(OrchestratorEffect.NavigateToLogin)
+                clearActioning(result.error.message)
+            }
+            is ApiResult.NetworkError -> clearActioning(OFFLINE)
+        }
+    }
+
+    private fun clearActioning(message: String?) {
+        val current = _uiState.value as? OrchestratorUiState.Content ?: return
+        _uiState.value = current.copy(actioning = null, actionError = message)
+    }
+
+    companion object {
+        const val ARG_WORKER_ID = "workerId"
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val OFFLINE = "Couldn't reach the server. Try again."
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/agents/workers/ui/WorkerDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/agents/workers/ui/WorkerDetailScreen.kt
@@ -48,12 +48,14 @@ object WorkerDetailTestTags {
     const val START = "worker_detail_start"
     const val STOP = "worker_detail_stop"
     const val TERMINATE = "worker_detail_terminate"
+    const val ORCHESTRATOR = "worker_detail_orchestrator"
 }
 
 @Composable
 fun WorkerDetailRoute(
     onBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onOpenOrchestrator: (String) -> Unit = {},
     viewModel: WorkerDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -73,6 +75,7 @@ fun WorkerDetailRoute(
         onStart = viewModel::start,
         onStop = viewModel::stop,
         onTerminate = viewModel::terminate,
+        onOpenOrchestrator = onOpenOrchestrator,
     )
 }
 
@@ -84,6 +87,7 @@ fun WorkerDetailScreen(
     onStart: () -> Unit,
     onStop: () -> Unit,
     onTerminate: () -> Unit,
+    onOpenOrchestrator: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var confirmTerminate by remember { mutableStateOf(false) }
@@ -111,6 +115,7 @@ fun WorkerDetailScreen(
                     onStart = onStart,
                     onStop = onStop,
                     onTerminate = { confirmTerminate = true },
+                    onOpenOrchestrator = onOpenOrchestrator,
                 )
         }
     }
@@ -134,6 +139,7 @@ private fun WorkerDetailContent(
     onStart: () -> Unit,
     onStop: () -> Unit,
     onTerminate: () -> Unit,
+    onOpenOrchestrator: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val worker = state.worker
@@ -179,6 +185,11 @@ private fun WorkerDetailContent(
                 ) { Text("Terminate") }
             }
         }
+
+        Button(
+            onClick = { onOpenOrchestrator(worker.id) },
+            modifier = Modifier.testTag(WorkerDetailTestTags.ORCHESTRATOR),
+        ) { Text("Manage agent loop") }
 
         HorizontalDivider()
         Text("Provision log", style = MaterialTheme.typography.titleMedium)

--- a/android/app/src/main/java/com/testlogon/android/navigation/AgentsNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/AgentsNavigation.kt
@@ -15,6 +15,8 @@ import com.testlogon.android.feature.agents.llmkeys.ui.LlmKeysListRoute
 import com.testlogon.android.feature.agents.memory.ui.MemoryRoute
 import com.testlogon.android.feature.agents.memory.ui.MemoryViewModel
 import com.testlogon.android.feature.agents.memory.ui.MemoryWorkerPickerRoute
+import com.testlogon.android.feature.agents.orchestrator.ui.OrchestratorRoute
+import com.testlogon.android.feature.agents.orchestrator.ui.OrchestratorViewModel
 import com.testlogon.android.feature.agents.prs.ui.PrDetailRoute
 import com.testlogon.android.feature.agents.prs.ui.PrDetailViewModel
 import com.testlogon.android.feature.agents.prs.ui.PrsListRoute
@@ -51,6 +53,13 @@ data object WorkerCreateDest {
 data object WorkerDetailDest {
     const val ROUTE = "agents/workers/{workerId}"
     fun build(workerId: String): String = "agents/workers/${android.net.Uri.encode(workerId)}"
+}
+
+/** AGENT-ORCHESTRATOR (web-parity): the agent-loop console for one worker (reached from worker detail). */
+data object OrchestratorDest {
+    const val ROUTE = "agents/workers/{workerId}/orchestrator"
+    fun build(workerId: String): String =
+        "agents/workers/${android.net.Uri.encode(workerId)}/orchestrator"
 }
 
 data object LlmKeysListDest {
@@ -123,6 +132,20 @@ fun NavGraphBuilder.agentsBasicsDestinations(navController: NavHostController) {
         arguments = listOf(navArgument(WorkerDetailViewModel.ARG_WORKER_ID) { type = NavType.StringType }),
     ) {
         WorkerDetailRoute(
+            onBack = { navController.popBackStack() },
+            onOpenOrchestrator = { id ->
+                navController.navigate(OrchestratorDest.build(id)) { launchSingleTop = true }
+            },
+            onNavigateToLogin = { navController.navigateToAgentsReauth() },
+        )
+    }
+
+    // ---- Orchestrator (agent-loop console for one worker) ----
+    composable(
+        route = OrchestratorDest.ROUTE,
+        arguments = listOf(navArgument(OrchestratorViewModel.ARG_WORKER_ID) { type = NavType.StringType }),
+    ) {
+        OrchestratorRoute(
             onBack = { navController.popBackStack() },
             onNavigateToLogin = { navController.navigateToAgentsReauth() },
         )

--- a/android/app/src/test/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/agents/orchestrator/data/OrchestratorMathTest.kt
@@ -1,0 +1,215 @@
+package com.testlogon.android.feature.agents.orchestrator.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - JVM unit tests for the PURE loop-lifecycle logic in [OrchestratorMath].
+ * Covers the action-availability guards (mirroring the backend transition rules), optimistic projection, and
+ * the heartbeat-age / staleness helpers.
+ */
+class OrchestratorMathTest {
+
+    private fun status(
+        state: AgentLoopState = AgentLoopState.IDLE,
+        loopRunning: Boolean = false,
+        currentTicketId: String = "",
+        heartbeatAt: Long = 0,
+        ticketsCompleted: Int = 0,
+    ) = AgentStatus(
+        workerId = "w1",
+        state = state,
+        currentTicketId = currentTicketId,
+        currentTicketTitle = if (currentTicketId.isNotBlank()) "Title" else "",
+        ticketsCompleted = ticketsCompleted,
+        ticketsFailed = 0,
+        heartbeatAt = heartbeatAt,
+        lastActivityAt = 0,
+        ticketFilter = TicketFilter(),
+        loopRunning = loopRunning,
+    )
+
+    // ---- state parsing ----
+
+    @Test
+    fun stateFrom_mapsKnownWireValues() {
+        assertEquals(AgentLoopState.WORKING, AgentLoopState.from("working"))
+        assertEquals(AgentLoopState.PAUSED, AgentLoopState.from("PAUSED"))
+        assertEquals(AgentLoopState.STOPPED, AgentLoopState.from(" stopped "))
+    }
+
+    @Test
+    fun stateFrom_unknownOrNull_isUnknown() {
+        assertEquals(AgentLoopState.UNKNOWN, AgentLoopState.from("frobnicating"))
+        assertEquals(AgentLoopState.UNKNOWN, AgentLoopState.from(null))
+        assertEquals(AgentLoopState.UNKNOWN, AgentLoopState.from(""))
+    }
+
+    // ---- action availability ----
+
+    @Test
+    fun idleStopped_offersStart_notPauseResume() {
+        val actions = OrchestratorMath.availableActions(status(state = AgentLoopState.IDLE, loopRunning = false))
+        assertTrue(LoopAction.START in actions)
+        assertFalse(LoopAction.PAUSE in actions)
+        assertFalse(LoopAction.RESUME in actions)
+    }
+
+    @Test
+    fun working_offersPauseAndStop_notStart() {
+        val actions = OrchestratorMath.availableActions(status(state = AgentLoopState.WORKING, loopRunning = true))
+        assertTrue(LoopAction.PAUSE in actions)
+        assertTrue(LoopAction.STOP in actions)
+        assertFalse(LoopAction.START in actions)
+    }
+
+    @Test
+    fun paused_offersResumeAndStop_notPause() {
+        val actions = OrchestratorMath.availableActions(status(state = AgentLoopState.PAUSED, loopRunning = true))
+        assertTrue(LoopAction.RESUME in actions)
+        assertTrue(LoopAction.STOP in actions)
+        assertFalse(LoopAction.PAUSE in actions)
+        assertFalse(LoopAction.START in actions)
+    }
+
+    @Test
+    fun idleButLoopRunning_offersPauseNotStart() {
+        // A worker can report state=idle while the loop is running (between tickets) -> no double-start.
+        val actions = OrchestratorMath.availableActions(status(state = AgentLoopState.IDLE, loopRunning = true))
+        assertFalse(LoopAction.START in actions)
+        assertTrue(LoopAction.PAUSE in actions)
+    }
+
+    @Test
+    fun noActiveTicket_offersClaim_notCompleteOrRelease() {
+        val actions = OrchestratorMath.availableActions(status(currentTicketId = ""))
+        assertTrue(LoopAction.CLAIM in actions)
+        assertFalse(LoopAction.COMPLETE in actions)
+        assertFalse(LoopAction.RELEASE in actions)
+    }
+
+    @Test
+    fun activeTicket_offersCompleteAndRelease_notClaim() {
+        val actions = OrchestratorMath.availableActions(
+            status(state = AgentLoopState.WORKING, loopRunning = true, currentTicketId = "t7"),
+        )
+        assertTrue(LoopAction.COMPLETE in actions)
+        assertTrue(LoopAction.RELEASE in actions)
+        assertFalse(LoopAction.CLAIM in actions)
+    }
+
+    @Test
+    fun heartbeat_alwaysAvailable() {
+        assertTrue(LoopAction.HEARTBEAT in OrchestratorMath.availableActions(status(state = AgentLoopState.STOPPED)))
+        assertTrue(LoopAction.HEARTBEAT in OrchestratorMath.availableActions(status(state = AgentLoopState.WORKING, loopRunning = true)))
+    }
+
+    @Test
+    fun convenienceGuards_matchAvailableActions() {
+        val s = status(state = AgentLoopState.PAUSED, loopRunning = true, currentTicketId = "t1")
+        assertTrue(OrchestratorMath.canResume(s))
+        assertTrue(OrchestratorMath.canStop(s))
+        assertTrue(OrchestratorMath.canComplete(s))
+        assertFalse(OrchestratorMath.canStart(s))
+        assertFalse(OrchestratorMath.canClaim(s))
+    }
+
+    // ---- projection ----
+
+    @Test
+    fun projectStart_setsWorkingAndRunning() {
+        val projected = OrchestratorMath.project(status(), LoopAction.START)
+        assertEquals(AgentLoopState.WORKING, projected.state)
+        assertTrue(projected.loopRunning)
+    }
+
+    @Test
+    fun projectStop_setsStoppedAndNotRunning() {
+        val projected = OrchestratorMath.project(status(state = AgentLoopState.WORKING, loopRunning = true), LoopAction.STOP)
+        assertEquals(AgentLoopState.STOPPED, projected.state)
+        assertFalse(projected.loopRunning)
+    }
+
+    @Test
+    fun projectClaim_seedsTicketId() {
+        val projected = OrchestratorMath.project(status(), LoopAction.CLAIM, claimedTicketId = "t99")
+        assertEquals("t99", projected.currentTicketId)
+    }
+
+    @Test
+    fun projectComplete_clearsTicketAndIncrementsCount() {
+        val s = status(state = AgentLoopState.WORKING, loopRunning = true, currentTicketId = "t1", ticketsCompleted = 3)
+        val projected = OrchestratorMath.project(s, LoopAction.COMPLETE)
+        assertEquals("", projected.currentTicketId)
+        assertEquals(4, projected.ticketsCompleted)
+        assertEquals(AgentLoopState.IDLE, projected.state)
+    }
+
+    @Test
+    fun projectRelease_clearsTicket_keepsCount() {
+        val s = status(state = AgentLoopState.WORKING, loopRunning = true, currentTicketId = "t1", ticketsCompleted = 3)
+        val projected = OrchestratorMath.project(s, LoopAction.RELEASE)
+        assertEquals("", projected.currentTicketId)
+        assertEquals(3, projected.ticketsCompleted)
+    }
+
+    @Test
+    fun projectHeartbeat_isIdentity() {
+        val s = status(state = AgentLoopState.WORKING, loopRunning = true, currentTicketId = "t1")
+        assertEquals(s, OrchestratorMath.project(s, LoopAction.HEARTBEAT))
+    }
+
+    // ---- heartbeat helpers ----
+
+    @Test
+    fun heartbeatAge_neverBeaten_isNull() {
+        assertNull(OrchestratorMath.heartbeatAgeSeconds(status(heartbeatAt = 0), nowSeconds = 1000))
+    }
+
+    @Test
+    fun heartbeatAge_computesPositiveAge() {
+        assertEquals(300L, OrchestratorMath.heartbeatAgeSeconds(status(heartbeatAt = 700), nowSeconds = 1000))
+    }
+
+    @Test
+    fun heartbeatAge_clockBehind_isNull() {
+        assertNull(OrchestratorMath.heartbeatAgeSeconds(status(heartbeatAt = 2000), nowSeconds = 1000))
+    }
+
+    @Test
+    fun isStale_runningAndOld_isTrue() {
+        val s = status(state = AgentLoopState.WORKING, loopRunning = true, heartbeatAt = 100)
+        assertTrue(OrchestratorMath.isHeartbeatStale(s, nowSeconds = 1000, staleThresholdSeconds = 60))
+    }
+
+    @Test
+    fun isStale_runningButFresh_isFalse() {
+        val s = status(state = AgentLoopState.WORKING, loopRunning = true, heartbeatAt = 990)
+        assertFalse(OrchestratorMath.isHeartbeatStale(s, nowSeconds = 1000, staleThresholdSeconds = 60))
+    }
+
+    @Test
+    fun isStale_notRunning_isFalse() {
+        val s = status(state = AgentLoopState.STOPPED, loopRunning = false, heartbeatAt = 1)
+        assertFalse(OrchestratorMath.isHeartbeatStale(s, nowSeconds = 100000, staleThresholdSeconds = 60))
+    }
+
+    @Test
+    fun summaryLine_reflectsStateRunningAndTicket() {
+        val s = status(state = AgentLoopState.WORKING, loopRunning = true, currentTicketId = "t1")
+        val line = OrchestratorMath.summaryLine(s)
+        assertTrue(line.contains("Working"))
+        assertTrue(line.contains("loop running"))
+        assertTrue(line.contains("Title"))
+    }
+
+    @Test
+    fun summaryLine_noTicket_saysNoActiveTicket() {
+        val line = OrchestratorMath.summaryLine(status(state = AgentLoopState.IDLE, loopRunning = false))
+        assertTrue(line.contains("no active ticket"))
+        assertTrue(line.contains("loop stopped"))
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agents/AgentsNetworkModule.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agents/AgentsNetworkModule.kt
@@ -53,4 +53,9 @@ object AgentsNetworkModule {
     @Singleton
     fun provideDocsApi(retrofit: Retrofit): DocsApi =
         retrofit.create(DocsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideOrchestratorApi(retrofit: Retrofit): OrchestratorApi =
+        retrofit.create(OrchestratorApi::class.java)
 }

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agents/OrchestratorApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agents/OrchestratorApi.kt
@@ -1,0 +1,71 @@
+package com.testlogon.android.core.network.agents
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - Retrofit interface for the agent-loop ORCHESTRATOR surface (web
+ * /ui/agent/orchestrator). Transport only; the :app repository folds these into ApiResult. Mirrors
+ * frontend/src/api/endpoints/agentOrchestrator.ts + backend app/routers/agent_orchestrator.py.
+ *
+ * Paths have NO leading slash (relative to the shared Retrofit base URL). The shared authenticated client
+ * attaches the session cookie jar + Authorization + X-CSRF-Token via the global interceptors; no per-call header
+ * wiring here. All endpoints are backend require_ui_session.
+ *
+ * [status], [checkpoint] (GET) and [eligibleTickets] are idempotent GETs. The loop-control (start/pause/resume/
+ * stop), ticket operations (claim/complete/release), checkpoint SAVE, heartbeat, ticket-filter PUT and
+ * create-worker are NON-idempotent mutations excluded from auto-retry.
+ */
+interface OrchestratorApi {
+
+    // -- Status --
+    @GET("ui/agent/orchestrator/{workerId}/status")
+    suspend fun status(@Path("workerId") workerId: String): AgentStatusDto
+
+    // -- Loop control --
+    @POST("ui/agent/orchestrator/{workerId}/start")
+    suspend fun start(@Path("workerId") workerId: String): LoopActionResultDto
+
+    @POST("ui/agent/orchestrator/{workerId}/pause")
+    suspend fun pause(@Path("workerId") workerId: String): LoopActionResultDto
+
+    @POST("ui/agent/orchestrator/{workerId}/resume")
+    suspend fun resume(@Path("workerId") workerId: String): LoopActionResultDto
+
+    @POST("ui/agent/orchestrator/{workerId}/stop")
+    suspend fun stop(@Path("workerId") workerId: String): LoopActionResultDto
+
+    // -- Ticket operations --
+    @POST("ui/agent/orchestrator/{workerId}/release-ticket")
+    suspend fun releaseTicket(@Path("workerId") workerId: String): ReleaseTicketResultDto
+
+    @POST("ui/agent/orchestrator/{workerId}/claim-ticket")
+    suspend fun claimTicket(
+        @Path("workerId") workerId: String,
+        @Body body: ClaimTicketRequest,
+    ): Map<String, Any?>
+
+    @POST("ui/agent/orchestrator/{workerId}/complete-ticket")
+    suspend fun completeTicket(
+        @Path("workerId") workerId: String,
+        @Body body: CompleteTicketRequest,
+    ): CompleteTicketResultDto
+
+    // -- Heartbeat --
+    @POST("ui/agent/orchestrator/{workerId}/heartbeat")
+    suspend fun heartbeat(@Path("workerId") workerId: String): HeartbeatResultDto
+
+    // -- Eligible tickets --
+    @GET("ui/agent/orchestrator/{workerId}/eligible-tickets")
+    suspend fun eligibleTickets(@Path("workerId") workerId: String): EligibleTicketsDto
+
+    // -- Ticket filter --
+    @PUT("ui/agent/orchestrator/{workerId}/ticket-filter")
+    suspend fun updateTicketFilter(
+        @Path("workerId") workerId: String,
+        @Body body: TicketFilterConfigDto,
+    ): Map<String, Any?>
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/agents/OrchestratorDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/agents/OrchestratorDtos.kt
@@ -1,0 +1,98 @@
+package com.testlogon.android.core.network.agents
+
+import com.squareup.moshi.Json
+
+/**
+ * AGENT-ORCHESTRATOR (web-parity) - transport DTOs for the agent-loop ORCHESTRATOR surface
+ * (backend app/routers/agent_orchestrator.py, prefix ui/agent/orchestrator; web
+ * frontend/src/api/endpoints/agentOrchestrator.ts).
+ *
+ * CODEGEN NOTE (identical to AgentsDtos / AgentsBasicsDtos): core-network does NOT apply Moshi KSP codegen, so
+ * these DTOs decode via the reflective KotlinJsonAdapterFactory registered on the shared Moshi. That factory maps
+ * property names to JSON keys VERBATIM (no auto snake_case), so every wire key is pinned with an explicit
+ * @Json(name = ...). @JsonClass(generateAdapter = true) is intentionally OMITTED.
+ *
+ * TIME fields are EPOCH SECONDS typed as Long (0 == "never"/"unset"). All paths are require_ui_session.
+ */
+
+/** The agent ticket-filter config (GET status embeds it; PUT ticket-filter sets it). */
+data class TicketFilterConfigDto(
+    @Json(name = "types") val types: List<String> = emptyList(),
+    @Json(name = "tags") val tags: List<String> = emptyList(),
+    @Json(name = "space_ids") val spaceIds: List<String> = emptyList(),
+    @Json(name = "priorities") val priorities: List<String> = emptyList(),
+)
+
+/** GET ui/agent/orchestrator/{worker_id}/status (AgentStatusOut). */
+data class AgentStatusDto(
+    @Json(name = "worker_id") val workerId: String = "",
+    @Json(name = "agent_state") val agentState: String = "idle",
+    @Json(name = "current_ticket_id") val currentTicketId: String = "",
+    @Json(name = "current_ticket_title") val currentTicketTitle: String = "",
+    @Json(name = "tickets_completed") val ticketsCompleted: Int = 0,
+    @Json(name = "tickets_failed") val ticketsFailed: Int = 0,
+    @Json(name = "heartbeat_at") val heartbeatAt: Long = 0,
+    @Json(name = "last_activity_at") val lastActivityAt: Long = 0,
+    @Json(name = "ticket_filter") val ticketFilter: TicketFilterConfigDto? = null,
+    @Json(name = "loop_running") val loopRunning: Boolean = false,
+)
+
+/** Common loop-control result (start/pause/resume/stop). Fields degrade when the server omits them. */
+data class LoopActionResultDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "worker_id") val workerId: String = "",
+    @Json(name = "agent_state") val agentState: String = "",
+    @Json(name = "current_ticket_id") val currentTicketId: String = "",
+    @Json(name = "message") val message: String = "",
+)
+
+/** POST .../release-ticket result. */
+data class ReleaseTicketResultDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "worker_id") val workerId: String = "",
+    @Json(name = "released_ticket_id") val releasedTicketId: String = "",
+    @Json(name = "agent_state") val agentState: String = "",
+)
+
+/** POST .../complete-ticket result. */
+data class CompleteTicketResultDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "worker_id") val workerId: String = "",
+    @Json(name = "completed_ticket_id") val completedTicketId: String = "",
+    @Json(name = "agent_state") val agentState: String = "",
+)
+
+/** POST .../heartbeat result. */
+data class HeartbeatResultDto(
+    @Json(name = "ok") val ok: Boolean = false,
+    @Json(name = "heartbeat_at") val heartbeatAt: Long = 0,
+)
+
+/** One eligible ticket (elements of EligibleTicketsOut.tickets; keys pinned, extras ignored). */
+data class EligibleTicketDto(
+    @Json(name = "ticket_id") val ticketId: String = "",
+    @Json(name = "title") val title: String = "",
+    @Json(name = "priority") val priority: String = "",
+    @Json(name = "type") val type: String = "",
+    @Json(name = "tags") val tags: List<String> = emptyList(),
+    @Json(name = "space_id") val spaceId: String = "",
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+/** GET .../eligible-tickets (EligibleTicketsOut). */
+data class EligibleTicketsDto(
+    @Json(name = "tickets") val tickets: List<EligibleTicketDto> = emptyList(),
+    @Json(name = "count") val count: Int = 0,
+    @Json(name = "filter_applied") val filterApplied: TicketFilterConfigDto? = null,
+)
+
+/** Body for POST .../claim-ticket. */
+data class ClaimTicketRequest(
+    @Json(name = "ticket_id") val ticketId: String,
+)
+
+/** Body for POST .../complete-ticket (both fields optional server-side). */
+data class CompleteTicketRequest(
+    @Json(name = "summary") val summary: String? = null,
+    @Json(name = "pr_url") val prUrl: String? = null,
+)


### PR DESCRIPTION
## FE parity PAR-151 - Android agent orchestration/fleet/workers

Brings the Android client to parity with the web agent fleet/orchestration surface.

### Changes
- New Android agent **orchestrator** feature module: screen, view model, UI state, repository, domain, mappers, and math (with unit test).
- New core-network orchestrator API + DTOs and Hilt data module wiring.
- Worker detail screen and agents navigation updated to route into the orchestrator.

All new surfaces are feature-gated. Backend unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
