### PR TITLE
FE sweep SWP-153b - Android K8s pod detail + SSH bastion path update

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/infrak8s/K8sApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/infrak8s/K8sApi.kt
@@ -45,6 +45,9 @@ interface K8sApi {
     @GET("ui/remote/k8s/pods")
     suspend fun pods(@Query("status") status: String? = null): K8sPodListDto
 
+    @GET("ui/remote/k8s/pods/{id}")
+    suspend fun getPod(@Path("id") podId: String): K8sPodDto
+
     @GET("ui/remote/k8s/pods/{id}/logs")
     suspend fun logs(@Path("id") podId: String, @Query("tail") tail: Int? = null): K8sPodLogsDto
 
@@ -121,6 +124,7 @@ data class K8sLaunchReq(
 interface K8sRepository {
     suspend fun reference(): ApiResult<K8sReference>
     suspend fun list(status: String?): ApiResult<K8sPodListDto>
+    suspend fun get(podId: String): ApiResult<K8sPodDto>
     suspend fun launch(req: K8sLaunchReq): ApiResult<K8sPodDto>
     suspend fun logs(podId: String): ApiResult<K8sPodLogsDto>
     suspend fun terminate(podId: String): ApiResult<K8sPodDto>
@@ -145,6 +149,9 @@ class DefaultK8sRepository @Inject constructor(
 
     override suspend fun list(status: String?): ApiResult<K8sPodListDto> =
         withContext(io) { call { api.pods(status?.takeIf { it.isNotBlank() }) } }
+
+    override suspend fun get(podId: String): ApiResult<K8sPodDto> =
+        withContext(io) { call { api.getPod(podId) } }
 
     override suspend fun launch(req: K8sLaunchReq): ApiResult<K8sPodDto> =
         withContext(io) { call { api.launch(req) } }

--- a/android/app/src/main/java/com/testlogon/android/data/infrasweep/InfraSweepMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/infrasweep/InfraSweepMath.kt
@@ -1,0 +1,106 @@
+package com.testlogon.android.data.infrasweep
+
+import com.testlogon.android.data.infrak8s.K8sPodDto
+import com.testlogon.android.data.sshbastion.BastionHopDto
+import com.testlogon.android.data.sshbastion.BastionHopReq
+import com.testlogon.android.data.sshbastion.BastionPathDto
+import com.testlogon.android.data.sshbastion.UpdateBastionPathReq
+
+/**
+ * Dev-platform SWEEP: pure, Android-free logic shared by the K8s pod-detail read
+ * (GET /ui/remote/k8s/pods/{id}) and the SSH-bastion edit-path write
+ * (PATCH /ui/compute/bastion/paths/{id}). Kept in a *Math file with a JVM test so the
+ * branching (change-detection, degrade-on-404 merge, edit-form -> PATCH mapping) is
+ * exercised without Compose/Moshi/Retrofit.
+ */
+object InfraSweepMath {
+
+    // ---- K8s pod-detail: degrade-on-404 merge ----------------------------------
+
+    /**
+     * Merge a freshly-fetched single-pod detail over the list-row summary.
+     *
+     * The detail read can 404 (pod GC'd) or fail transiently; on any non-success the
+     * caller passes [detail] = null and we degrade to the [fallback] list row so the
+     * user still sees *something*. When [detail] is present we prefer it, but never let
+     * a blank/zero field from the detail blank-out a value the list row already had
+     * (defensive against partial serialisations).
+     */
+    fun mergePodDetail(fallback: K8sPodDto, detail: K8sPodDto?): K8sPodDto {
+        if (detail == null) return fallback
+        return detail.copy(
+            podId = detail.podId.ifBlank { fallback.podId },
+            k8sPodName = detail.k8sPodName.ifBlank { fallback.k8sPodName },
+            namespace = detail.namespace.ifBlank { fallback.namespace },
+            label = detail.label.ifBlank { fallback.label },
+            image = detail.image.ifBlank { fallback.image },
+            imageDisplayName = detail.imageDisplayName.ifBlank { fallback.imageDisplayName },
+            preset = detail.preset.ifBlank { fallback.preset },
+            status = detail.status.ifBlank { fallback.status },
+            podIp = detail.podIp.ifBlank { fallback.podIp },
+            serviceHostname = detail.serviceHostname.ifBlank { fallback.serviceHostname },
+            cpuMillicores = if (detail.cpuMillicores != 0) detail.cpuMillicores else fallback.cpuMillicores,
+            memoryMb = if (detail.memoryMb != 0) detail.memoryMb else fallback.memoryMb,
+            createdAt = if (detail.createdAt != 0L) detail.createdAt else fallback.createdAt,
+            expiresAt = if (detail.expiresAt != 0L) detail.expiresAt else fallback.expiresAt,
+        )
+    }
+
+    // ---- SSH-bastion edit form -> PATCH body -----------------------------------
+
+    /** True once the edit form has enough to PATCH: a non-blank target host + user. */
+    fun isEditValid(targetHost: String, targetUser: String, label: String): Boolean =
+        targetHost.isNotBlank() && targetUser.isNotBlank() && label.isNotBlank()
+
+    /**
+     * Extract the single jump hop (the bastion) from a path for pre-filling the edit form.
+     * Returns the first hop flagged is_bastion, else the first non-last hop, else null.
+     */
+    fun primaryJumpHop(path: BastionPathDto): BastionHopDto? {
+        val hops = path.hops
+        if (hops.isEmpty()) return null
+        hops.firstOrNull { it.isBastion }?.let { return it }
+        return if (hops.size >= 2) hops.first() else null
+    }
+
+    /** Extract the target hop (last hop) from a path for pre-filling the edit form. */
+    fun targetHop(path: BastionPathDto): BastionHopDto? = path.hops.lastOrNull()
+
+    /**
+     * Build the PATCH body from the edited form. Backend semantics: any field left null is
+     * unchanged; jump_hops + target are replaced *together* when the chain is edited. We always
+     * send label/description (cheap idempotent) and, since this form always edits the chain,
+     * send jump_hops + target together. A blank jump host means "no bastion" -> empty jump list.
+     */
+    fun buildUpdate(
+        original: BastionPathDto,
+        label: String,
+        description: String,
+        jumpHost: String,
+        jumpUser: String,
+        targetHost: String,
+        targetUser: String,
+    ): UpdateBastionPathReq {
+        val jumps = if (jumpHost.isNotBlank()) {
+            listOf(
+                BastionHopReq(
+                    hostname = jumpHost.trim(),
+                    username = jumpUser.trim(),
+                    label = "bastion",
+                ),
+            )
+        } else {
+            emptyList()
+        }
+        return UpdateBastionPathReq(
+            label = label.trim().takeIf { it != original.label } ?: label.trim(),
+            description = description.trim(),
+            jumpHops = jumps,
+            target = BastionHopReq(
+                hostname = targetHost.trim(),
+                username = targetUser.trim(),
+                label = "target",
+            ),
+        )
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/sshbastion/SshBastionApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/sshbastion/SshBastionApi.kt
@@ -19,6 +19,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PATCH
 import retrofit2.http.Path
 import java.io.IOException
 import java.net.SocketTimeoutException
@@ -42,6 +43,9 @@ interface SshBastionApi {
 
     @POST("ui/compute/bastion/paths")
     suspend fun createPath(@Body body: CreateBastionPathReq): BastionPathDto
+
+    @PATCH("ui/compute/bastion/paths/{id}")
+    suspend fun updatePath(@Path("id") pathId: String, @Body body: UpdateBastionPathReq): BastionPathDto
 
     @GET("ui/compute/bastion/paths/{id}/resolve")
     suspend fun resolve(@Path("id") pathId: String): BastionResolvedDto
@@ -96,6 +100,14 @@ data class CreateBastionPathReq(
 )
 
 @JsonClass(generateAdapter = true)
+data class UpdateBastionPathReq(
+    @Json(name = "label") val label: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "jump_hops") val jumpHops: List<BastionHopReq>? = null,
+    @Json(name = "target") val target: BastionHopReq? = null,
+)
+
+@JsonClass(generateAdapter = true)
 data class BastionResolvedDto(
     @Json(name = "path_id") val pathId: String = "",
     @Json(name = "label") val label: String = "",
@@ -111,6 +123,7 @@ data class BastionResolvedDto(
 interface SshBastionRepository {
     suspend fun list(): ApiResult<BastionPathListDto>
     suspend fun create(req: CreateBastionPathReq): ApiResult<BastionPathDto>
+    suspend fun update(pathId: String, req: UpdateBastionPathReq): ApiResult<BastionPathDto>
     suspend fun resolve(pathId: String): ApiResult<BastionResolvedDto>
     suspend fun delete(pathId: String): ApiResult<Unit>
 }
@@ -127,6 +140,9 @@ class DefaultSshBastionRepository @Inject constructor(
 
     override suspend fun create(req: CreateBastionPathReq): ApiResult<BastionPathDto> =
         withContext(io) { call { api.createPath(req) } }
+
+    override suspend fun update(pathId: String, req: UpdateBastionPathReq): ApiResult<BastionPathDto> =
+        withContext(io) { call { api.updatePath(pathId, req) } }
 
     override suspend fun resolve(pathId: String): ApiResult<BastionResolvedDto> =
         withContext(io) { call { api.resolve(pathId) } }

--- a/android/app/src/main/java/com/testlogon/android/feature/infrak8s/K8sScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/infrak8s/K8sScreen.kt
@@ -71,8 +71,10 @@ object K8sTestTags {
     const val LAUNCH_PRESET = "k8s_launch_preset"
     const val LAUNCH_CONFIRM = "k8s_launch_confirm"
     const val LOGS_DIALOG = "k8s_logs_dialog"
+    const val DETAIL_DIALOG = "k8s_detail_dialog"
     fun row(id: String) = "k8s_row_$id"
     fun logs(id: String) = "k8s_logs_$id"
+    fun detail(id: String) = "k8s_detail_$id"
     fun terminate(id: String) = "k8s_terminate_$id"
 }
 
@@ -91,6 +93,8 @@ fun K8sRoute(
         onTerminate = viewModel::terminate,
         onOpenLogs = viewModel::openLogs,
         onCloseLogs = viewModel::closeLogs,
+        onOpenDetail = viewModel::openDetail,
+        onCloseDetail = viewModel::closeDetail,
         onMessageShown = viewModel::clearMessage,
     )
 }
@@ -105,6 +109,8 @@ fun K8sScreen(
     onTerminate: (String) -> Unit,
     onOpenLogs: (String) -> Unit,
     onCloseLogs: () -> Unit,
+    onOpenDetail: (K8sPodDto) -> Unit,
+    onCloseDetail: () -> Unit,
     onMessageShown: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -181,7 +187,8 @@ fun K8sScreen(
                             pod = pod,
                             inFlight = state.actionInFlightId == pod.podId,
                             actionsEnabled = state.actionInFlightId == null,
-                            onLogs = { onOpenLogs(pod.podId) },
+                            onDetails = { onOpenDetail(pod) },
+                        onLogs = { onOpenLogs(pod.podId) },
                             onTerminate = { onTerminate(pod.podId) },
                         )
                     }
@@ -206,6 +213,10 @@ fun K8sScreen(
     state.logs?.let { logsState ->
         LogsDialog(logsState = logsState, onDismiss = onCloseLogs)
     }
+
+    state.detail?.let { detailState ->
+        DetailDialog(detailState = detailState, onDismiss = onCloseDetail)
+    }
 }
 
 @Composable
@@ -213,6 +224,7 @@ private fun K8sRow(
     pod: K8sPodDto,
     inFlight: Boolean,
     actionsEnabled: Boolean,
+    onDetails: () -> Unit,
     onLogs: () -> Unit,
     onTerminate: () -> Unit,
 ) {
@@ -251,6 +263,11 @@ private fun K8sRow(
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) { CircularProgressIndicator() }
             } else {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                    OutlinedButton(
+                        onClick = onDetails,
+                        enabled = actionsEnabled,
+                        modifier = Modifier.testTag(K8sTestTags.detail(pod.podId)),
+                    ) { Text("Details") }
                     OutlinedButton(
                         onClick = onLogs,
                         enabled = actionsEnabled,
@@ -323,6 +340,47 @@ private fun DeployDialog(
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
+}
+
+@Composable
+private fun DetailDialog(detailState: K8sDetailState, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(K8sTestTags.DETAIL_DIALOG),
+        title = { Text("Pod detail") },
+        text = {
+            when (detailState) {
+                is K8sDetailState.Loading -> Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) { CircularProgressIndicator() }
+                is K8sDetailState.Error -> Text(infraErrorMessage(detailState.type))
+                is K8sDetailState.Loaded -> {
+                    val p = detailState.pod
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        DetailRow("Label", p.label.ifBlank { "-" })
+                        DetailRow("Status", p.status.ifBlank { "-" })
+                        DetailRow("Namespace", p.namespace.ifBlank { "-" })
+                        DetailRow("Pod name", p.k8sPodName.ifBlank { "-" })
+                        DetailRow("Image", p.imageDisplayName.ifBlank { p.image.ifBlank { "-" } })
+                        DetailRow("Preset", p.preset.ifBlank { "-" })
+                        DetailRow("Resources", "${p.cpuMillicores}m CPU / ${p.memoryMb} MB")
+                        DetailRow("Pod IP", p.podIp.ifBlank { "-" })
+                        DetailRow("Service", p.serviceHostname.ifBlank { "-" })
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodySmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/testlogon/android/feature/infrak8s/K8sViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/infrak8s/K8sViewModel.kt
@@ -7,6 +7,7 @@ import com.testlogon.android.data.infrak8s.K8sLaunchReq
 import com.testlogon.android.data.infrak8s.K8sPodDto
 import com.testlogon.android.data.infrak8s.K8sReference
 import com.testlogon.android.data.infrak8s.K8sRepository
+import com.testlogon.android.data.infrasweep.InfraSweepMath
 import com.testlogon.android.feature.adminmod.AdminOpsErrorType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,12 +35,20 @@ sealed interface K8sLogsState {
     data class Error(val type: AdminOpsErrorType) : K8sLogsState
 }
 
+/** Pod-detail modal state (GET /pods/{id}); degrades to the list row on 404. */
+sealed interface K8sDetailState {
+    data object Loading : K8sDetailState
+    data class Loaded(val pod: K8sPodDto) : K8sDetailState
+    data class Error(val type: AdminOpsErrorType) : K8sDetailState
+}
+
 data class K8sUiState(
     val data: K8sDataState = K8sDataState.Loading,
     val reference: K8sReference? = null,
     val actionInFlightId: String? = null,
     val launchInFlight: Boolean = false,
     val logs: K8sLogsState? = null,
+    val detail: K8sDetailState? = null,
     val message: String? = null,
     val transientError: AdminOpsErrorType? = null,
 )
@@ -154,6 +163,37 @@ class K8sViewModel @Inject constructor(
 
     fun closeLogs() {
         _state.value = _state.value.copy(logs = null)
+    }
+    /**
+     * Open the pod detail (GET /pods/{id}). Reads the single pod fresh instead of filtering the
+     * cached list; on 404/any failure we degrade to the [fallback] list row so the sheet still opens.
+     */
+    fun openDetail(fallback: K8sPodDto) {
+        _state.value = _state.value.copy(detail = K8sDetailState.Loading)
+        viewModelScope.launch {
+            when (val r = repo.get(fallback.podId)) {
+                is ApiResult.Success ->
+                    _state.value = _state.value.copy(
+                        detail = K8sDetailState.Loaded(InfraSweepMath.mergePodDetail(fallback, r.data)),
+                    )
+                is ApiResult.Failure ->
+                    if (r.error.status == 404) {
+                        _state.value = _state.value.copy(
+                            detail = K8sDetailState.Loaded(InfraSweepMath.mergePodDetail(fallback, null)),
+                        )
+                    } else {
+                        _state.value = _state.value.copy(
+                            detail = K8sDetailState.Error(if (r.error.status == 401) AdminOpsErrorType.AUTH else AdminOpsErrorType.SERVER),
+                        )
+                    }
+                is ApiResult.NetworkError ->
+                    _state.value = _state.value.copy(detail = K8sDetailState.Error(AdminOpsErrorType.NETWORK))
+            }
+        }
+    }
+
+    fun closeDetail() {
+        _state.value = _state.value.copy(detail = null)
     }
 
     fun clearMessage() {

--- a/android/app/src/main/java/com/testlogon/android/feature/sshbastion/SshBastionScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/sshbastion/SshBastionScreen.kt
@@ -52,7 +52,9 @@ import com.testlogon.android.core.ui.state.LoadingState
 import com.testlogon.android.data.sshbastion.BastionHopReq
 import com.testlogon.android.data.sshbastion.BastionPathDto
 import com.testlogon.android.data.sshbastion.CreateBastionPathReq
+import com.testlogon.android.data.sshbastion.UpdateBastionPathReq
 import com.testlogon.android.feature.infracommon.infraErrorMessage
+import com.testlogon.android.data.infrasweep.InfraSweepMath
 
 object SshBastionTestTags {
     const val SCREEN = "sshbastion_screen"
@@ -66,6 +68,7 @@ object SshBastionTestTags {
     const val FORM_TARGET_HOST = "sshbastion_form_target_host"
     const val FORM_CONFIRM = "sshbastion_form_confirm"
     fun row(id: String) = "sshbastion_row_$id"
+    fun edit(id: String) = "sshbastion_edit_$id"
     fun resolve(id: String) = "sshbastion_resolve_$id"
     fun delete(id: String) = "sshbastion_delete_$id"
 }
@@ -82,6 +85,7 @@ fun SshBastionRoute(
         onRefresh = viewModel::refresh,
         onRetry = viewModel::retry,
         onCreate = viewModel::create,
+        onUpdate = viewModel::update,
         onResolve = viewModel::resolve,
         onDelete = viewModel::delete,
         onDismissResolved = viewModel::dismissResolved,
@@ -96,6 +100,7 @@ fun SshBastionScreen(
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
     onCreate: (CreateBastionPathReq) -> Unit,
+    onUpdate: (String, UpdateBastionPathReq) -> Unit,
     onResolve: (String) -> Unit,
     onDelete: (String) -> Unit,
     onDismissResolved: () -> Unit,
@@ -105,6 +110,7 @@ fun SshBastionScreen(
     val snackbar = remember { SnackbarHostState() }
     var showCreate by remember { mutableStateOf(false) }
     var deleteTarget by remember { mutableStateOf<BastionPathDto?>(null) }
+    var editTarget by remember { mutableStateOf<BastionPathDto?>(null) }
     val clipboard = LocalClipboardManager.current
 
     LaunchedEffect(state.message, state.transientError) {
@@ -172,6 +178,7 @@ fun SshBastionScreen(
                             path = p,
                             inFlight = state.actionInFlightId == p.pathId,
                             actionsEnabled = state.actionInFlightId == null,
+                            onEdit = { editTarget = p },
                             onResolve = { onResolve(p.pathId) },
                             onDelete = { deleteTarget = p },
                         )
@@ -184,8 +191,45 @@ fun SshBastionScreen(
     if (showCreate) {
         BastionFormDialog(
             mutating = state.mutating,
+            existing = null,
             onDismiss = { showCreate = false },
-            onSubmit = { onCreate(it); showCreate = false },
+            onSubmitFields = { label, description, jumpHost, jumpUser, targetHost, targetUser ->
+                val jumps = if (jumpHost.isNotBlank()) {
+                    listOf(BastionHopReq(hostname = jumpHost.trim(), username = jumpUser.trim(), label = "bastion"))
+                } else emptyList()
+                onCreate(
+                    CreateBastionPathReq(
+                        label = label.trim(),
+                        description = description.trim(),
+                        jumpHops = jumps,
+                        target = BastionHopReq(hostname = targetHost.trim(), username = targetUser.trim(), label = "target"),
+                    ),
+                )
+                showCreate = false
+            },
+        )
+    }
+
+    editTarget?.let { p ->
+        BastionFormDialog(
+            mutating = state.mutating,
+            existing = p,
+            onDismiss = { editTarget = null },
+            onSubmitFields = { label, description, jumpHost, jumpUser, targetHost, targetUser ->
+                onUpdate(
+                    p.pathId,
+                    InfraSweepMath.buildUpdate(
+                        original = p,
+                        label = label,
+                        description = description,
+                        jumpHost = jumpHost,
+                        jumpUser = jumpUser,
+                        targetHost = targetHost,
+                        targetUser = targetUser,
+                    ),
+                )
+                editTarget = null
+            },
         )
     }
 
@@ -231,6 +275,7 @@ private fun BastionPathRow(
     path: BastionPathDto,
     inFlight: Boolean,
     actionsEnabled: Boolean,
+    onEdit: () -> Unit,
     onResolve: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -260,6 +305,11 @@ private fun BastionPathRow(
                         modifier = Modifier.testTag(SshBastionTestTags.resolve(path.pathId)),
                     ) { Text("Resolve") }
                     OutlinedButton(
+                        onClick = onEdit,
+                        enabled = actionsEnabled,
+                        modifier = Modifier.testTag(SshBastionTestTags.edit(path.pathId)),
+                    ) { Text("Edit") }
+                    OutlinedButton(
                         onClick = onDelete,
                         enabled = actionsEnabled,
                         modifier = Modifier.testTag(SshBastionTestTags.delete(path.pathId)),
@@ -273,19 +323,23 @@ private fun BastionPathRow(
 @Composable
 private fun BastionFormDialog(
     mutating: Boolean,
+    existing: BastionPathDto?,
     onDismiss: () -> Unit,
-    onSubmit: (CreateBastionPathReq) -> Unit,
+    onSubmitFields: (label: String, description: String, jumpHost: String, jumpUser: String, targetHost: String, targetUser: String) -> Unit,
 ) {
-    var label by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
-    var jumpHost by remember { mutableStateOf("") }
-    var jumpUser by remember { mutableStateOf("") }
-    var targetHost by remember { mutableStateOf("") }
-    var targetUser by remember { mutableStateOf("") }
+    val editing = existing != null
+    val jumpHop = existing?.let { InfraSweepMath.primaryJumpHop(it) }
+    val targetHopInit = existing?.let { InfraSweepMath.targetHop(it) }
+    var label by remember { mutableStateOf(existing?.label ?: "") }
+    var description by remember { mutableStateOf(existing?.description ?: "") }
+    var jumpHost by remember { mutableStateOf(jumpHop?.hostname ?: "") }
+    var jumpUser by remember { mutableStateOf(jumpHop?.username ?: "") }
+    var targetHost by remember { mutableStateOf(targetHopInit?.hostname ?: "") }
+    var targetUser by remember { mutableStateOf(targetHopInit?.username ?: "") }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("New bastion path") },
+        title = { Text(if (editing) "Edit bastion path" else "New bastion path") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedTextField(
@@ -335,24 +389,14 @@ private fun BastionFormDialog(
             }
         },
         confirmButton = {
-            val valid = label.isNotBlank() && targetHost.isNotBlank() && targetUser.isNotBlank()
+            val valid = InfraSweepMath.isEditValid(targetHost, targetUser, label)
             TextButton(
                 onClick = {
-                    val jumps = if (jumpHost.isNotBlank()) {
-                        listOf(BastionHopReq(hostname = jumpHost.trim(), username = jumpUser.trim(), label = "bastion"))
-                    } else emptyList()
-                    onSubmit(
-                        CreateBastionPathReq(
-                            label = label.trim(),
-                            description = description.trim(),
-                            jumpHops = jumps,
-                            target = BastionHopReq(hostname = targetHost.trim(), username = targetUser.trim(), label = "target"),
-                        ),
-                    )
+                    onSubmitFields(label, description, jumpHost, jumpUser, targetHost, targetUser)
                 },
                 enabled = !mutating && valid,
                 modifier = Modifier.testTag(SshBastionTestTags.FORM_CONFIRM),
-            ) { Text(if (mutating) "Saving..." else "Create") }
+            ) { Text(if (mutating) "Saving..." else if (editing) "Save" else "Create") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )

--- a/android/app/src/main/java/com/testlogon/android/feature/sshbastion/SshBastionViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/sshbastion/SshBastionViewModel.kt
@@ -6,6 +6,7 @@ import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.data.sshbastion.BastionPathDto
 import com.testlogon.android.data.sshbastion.BastionResolvedDto
 import com.testlogon.android.data.sshbastion.CreateBastionPathReq
+import com.testlogon.android.data.sshbastion.UpdateBastionPathReq
 import com.testlogon.android.data.sshbastion.SshBastionRepository
 import com.testlogon.android.feature.adminmod.AdminOpsErrorType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -84,6 +85,20 @@ class SshBastionViewModel @Inject constructor(
             when (val r = repo.create(req)) {
                 is ApiResult.Success -> {
                     _state.value = _state.value.copy(mutating = false, message = "Created ${r.data.label}")
+                    fetch(isRefresh = true)
+                }
+                is ApiResult.Failure -> reduceMutateError(if (r.error.status == 401) AdminOpsErrorType.AUTH else AdminOpsErrorType.SERVER)
+                is ApiResult.NetworkError -> reduceMutateError(AdminOpsErrorType.NETWORK)
+            }
+        }
+    }
+    fun update(pathId: String, req: UpdateBastionPathReq) {
+        if (_state.value.mutating) return
+        _state.value = _state.value.copy(mutating = true, transientError = null, message = null)
+        viewModelScope.launch {
+            when (val r = repo.update(pathId, req)) {
+                is ApiResult.Success -> {
+                    _state.value = _state.value.copy(mutating = false, message = "Updated ${r.data.label}")
                     fetch(isRefresh = true)
                 }
                 is ApiResult.Failure -> reduceMutateError(if (r.error.status == 401) AdminOpsErrorType.AUTH else AdminOpsErrorType.SERVER)

--- a/android/app/src/test/java/com/testlogon/android/data/infrasweep/InfraSweepMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/infrasweep/InfraSweepMathTest.kt
@@ -1,0 +1,181 @@
+package com.testlogon.android.data.infrasweep
+
+import com.testlogon.android.data.infrak8s.K8sPodDto
+import com.testlogon.android.data.sshbastion.BastionHopDto
+import com.testlogon.android.data.sshbastion.BastionPathDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM unit tests for the PURE [InfraSweepMath] dev-platform sweep logic (no Android/Moshi/Retrofit):
+ * K8s pod-detail degrade-on-404 merge + SSH-bastion edit-form -> PATCH mapping.
+ */
+class InfraSweepMathTest {
+
+    // ---- mergePodDetail --------------------------------------------------------
+
+    private fun listRow() = K8sPodDto(
+        podId = "p1",
+        k8sPodName = "pod-p1",
+        namespace = "ns",
+        label = "web",
+        image = "img:1",
+        imageDisplayName = "Web Image",
+        preset = "small",
+        cpuMillicores = 250,
+        memoryMb = 512,
+        status = "running",
+        podIp = "10.0.0.1",
+        serviceHostname = "web.svc",
+        createdAt = 100L,
+        expiresAt = 200L,
+    )
+
+    @Test
+    fun merge_nullDetail_degradesToListRow() {
+        val row = listRow()
+        assertEquals(row, InfraSweepMath.mergePodDetail(row, null))
+    }
+
+    @Test
+    fun merge_prefersDetailFields() {
+        val row = listRow()
+        val detail = row.copy(status = "terminated", podIp = "10.0.0.9", cpuMillicores = 500)
+        val merged = InfraSweepMath.mergePodDetail(row, detail)
+        assertEquals("terminated", merged.status)
+        assertEquals("10.0.0.9", merged.podIp)
+        assertEquals(500, merged.cpuMillicores)
+    }
+
+    @Test
+    fun merge_blankDetailStringDoesNotBlankRow() {
+        val row = listRow()
+        val detail = row.copy(status = "", podIp = "", imageDisplayName = "")
+        val merged = InfraSweepMath.mergePodDetail(row, detail)
+        assertEquals("running", merged.status)
+        assertEquals("10.0.0.1", merged.podIp)
+        assertEquals("Web Image", merged.imageDisplayName)
+    }
+
+    @Test
+    fun merge_zeroNumericDetailDoesNotZeroRow() {
+        val row = listRow()
+        val detail = row.copy(cpuMillicores = 0, memoryMb = 0, createdAt = 0L, expiresAt = 0L)
+        val merged = InfraSweepMath.mergePodDetail(row, detail)
+        assertEquals(250, merged.cpuMillicores)
+        assertEquals(512, merged.memoryMb)
+        assertEquals(100L, merged.createdAt)
+        assertEquals(200L, merged.expiresAt)
+    }
+
+    @Test
+    fun merge_keepsNonZeroDetailNumerics() {
+        val row = listRow()
+        val detail = row.copy(memoryMb = 1024, expiresAt = 999L)
+        val merged = InfraSweepMath.mergePodDetail(row, detail)
+        assertEquals(1024, merged.memoryMb)
+        assertEquals(999L, merged.expiresAt)
+    }
+
+    // ---- isEditValid -----------------------------------------------------------
+
+    @Test
+    fun isEditValid_requiresAllThree() {
+        assertTrue(InfraSweepMath.isEditValid("host", "user", "label"))
+        assertFalse(InfraSweepMath.isEditValid("", "user", "label"))
+        assertFalse(InfraSweepMath.isEditValid("host", "", "label"))
+        assertFalse(InfraSweepMath.isEditValid("host", "user", ""))
+        assertFalse(InfraSweepMath.isEditValid("  ", "user", "label"))
+    }
+
+    // ---- primaryJumpHop / targetHop --------------------------------------------
+
+    private fun path(vararg hops: BastionHopDto) = BastionPathDto(
+        pathId = "b1",
+        label = "chain",
+        description = "d",
+        hops = hops.toList(),
+        totalHops = hops.size,
+    )
+
+    @Test
+    fun primaryJumpHop_prefersBastionFlag() {
+        val p = path(
+            BastionHopDto(hostname = "j1", isBastion = true, hopNumber = 0),
+            BastionHopDto(hostname = "t", hopNumber = 1),
+        )
+        assertEquals("j1", InfraSweepMath.primaryJumpHop(p)?.hostname)
+    }
+
+    @Test
+    fun primaryJumpHop_fallsBackToFirstOfMulti() {
+        val p = path(
+            BastionHopDto(hostname = "j1", hopNumber = 0),
+            BastionHopDto(hostname = "t", hopNumber = 1),
+        )
+        assertEquals("j1", InfraSweepMath.primaryJumpHop(p)?.hostname)
+    }
+
+    @Test
+    fun primaryJumpHop_singleHop_isNull() {
+        val p = path(BastionHopDto(hostname = "only", hopNumber = 0))
+        assertNull(InfraSweepMath.primaryJumpHop(p))
+    }
+
+    @Test
+    fun primaryJumpHop_emptyHops_isNull() {
+        assertNull(InfraSweepMath.primaryJumpHop(path()))
+    }
+
+    @Test
+    fun targetHop_isLast() {
+        val p = path(
+            BastionHopDto(hostname = "j1", hopNumber = 0),
+            BastionHopDto(hostname = "target", hopNumber = 1),
+        )
+        assertEquals("target", InfraSweepMath.targetHop(p)?.hostname)
+        assertNull(InfraSweepMath.targetHop(path()))
+    }
+
+    // ---- buildUpdate -----------------------------------------------------------
+
+    @Test
+    fun buildUpdate_withJump_includesSingleBastion() {
+        val req = InfraSweepMath.buildUpdate(
+            original = path(),
+            label = " prod ",
+            description = " desc ",
+            jumpHost = " bastion.example ",
+            jumpUser = " ec2-user ",
+            targetHost = " app.internal ",
+            targetUser = " root ",
+        )
+        assertEquals("prod", req.label)
+        assertEquals("desc", req.description)
+        assertEquals(1, req.jumpHops!!.size)
+        assertEquals("bastion.example", req.jumpHops!![0].hostname)
+        assertEquals("ec2-user", req.jumpHops!![0].username)
+        assertEquals("bastion", req.jumpHops!![0].label)
+        assertEquals("app.internal", req.target!!.hostname)
+        assertEquals("root", req.target!!.username)
+        assertEquals("target", req.target!!.label)
+    }
+
+    @Test
+    fun buildUpdate_blankJump_emptyJumpList() {
+        val req = InfraSweepMath.buildUpdate(
+            original = path(),
+            label = "direct",
+            description = "",
+            jumpHost = "   ",
+            jumpUser = "ignored",
+            targetHost = "host",
+            targetUser = "user",
+        )
+        assertTrue(req.jumpHops!!.isEmpty())
+        assertEquals("host", req.target!!.hostname)
+    }
+}


### PR DESCRIPTION
## FE sweep SWP-153b

Ships the Android K8s pod-detail surface and an SSH bastion connection-path update.

- K8s: pod-detail API + screen + view model
- SSH bastion: connection path handling update (API + screen + view model)
- Shared infrasweep math helper with unit-test coverage

All changes built and gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
