### PR TITLE
FE sweep SWP-145a - Android workflow-rules mutations + drip sequences

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/DripSequencesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/DripSequencesScreen.kt
@@ -1,0 +1,232 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.workflow
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/** WFL — stable testTags for the drip-sequences screen. */
+object DripSequencesTestTags {
+    const val SCREEN = "drip_sequences_screen"
+    const val FAB_CREATE = "drip_sequences_fab_create"
+    const val CREATE_SUBMIT = "drip_sequence_create_submit"
+    fun row(sequenceId: String): String = "drip_sequence_row_$sequenceId"
+}
+
+@Composable
+fun DripSequencesRoute(
+    onBack: () -> Unit,
+    viewModel: DripSequencesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    DripSequencesScreen(
+        state = state,
+        onBack = onBack,
+        onCreate = { name, desc, stages, onDone ->
+            viewModel.createSequence(name, desc, stages, onDone)
+        },
+        onMessageShown = viewModel::consumeMessage,
+    )
+}
+
+@Composable
+fun DripSequencesScreen(
+    state: DripSequencesUiState,
+    onBack: () -> Unit,
+    onCreate: (String, String, List<DripStage>, () -> Unit) -> Unit,
+    onMessageShown: () -> Unit,
+) {
+    val snackbar = remember { SnackbarHostState() }
+    var showCreate by rememberSaveable { mutableStateOf(false) }
+
+    val message = (state as? DripSequencesUiState.Content)?.message
+    LaunchedEffect(message) {
+        if (message != null) {
+            snackbar.showSnackbar(message)
+            onMessageShown()
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag(DripSequencesTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbar) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Drip sequences") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (state is DripSequencesUiState.Content || state is DripSequencesUiState.Empty) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    modifier = Modifier.testTag(DripSequencesTestTags.FAB_CREATE),
+                ) { Icon(Icons.Filled.Add, contentDescription = "New sequence") }
+            }
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when (state) {
+                is DripSequencesUiState.Loading ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                is DripSequencesUiState.Unavailable ->
+                    CenterMsg("Drip sequences aren't available.")
+
+                is DripSequencesUiState.Empty ->
+                    CenterMsg("No drip sequences yet. Tap + to create one.")
+
+                is DripSequencesUiState.Error ->
+                    CenterMsg(state.error.message)
+
+                is DripSequencesUiState.Content -> LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(state.sequences, key = { it.sequenceId }) { seq -> SequenceRow(seq) }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CreateDripDialog(
+            onDismiss = { showCreate = false },
+            onSubmit = { name, desc, stages -> onCreate(name, desc, stages) { showCreate = false } },
+        )
+    }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.BoxScope.CenterMsg(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+    )
+}
+
+@Composable
+private fun SequenceRow(seq: DripSequence) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(DripSequencesTestTags.row(seq.sequenceId))) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(seq.name, style = MaterialTheme.typography.titleMedium)
+            seq.description.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.bodyMedium)
+            }
+            Text("${seq.stageCount} stages", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun CreateDripDialog(
+    onDismiss: () -> Unit,
+    onSubmit: (String, String, List<DripStage>) -> Unit,
+) {
+    var name by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
+    var templateId by rememberSaveable { mutableStateOf("") }
+    var toField by rememberSaveable { mutableStateOf("email") }
+    var delayHoursText by rememberSaveable { mutableStateOf("24") }
+
+    val delayHours = delayHoursText.toIntOrNull() ?: -1
+    val stages = listOf(
+        DripStage(stageNumber = 1, delayHours = delayHours, templateId = templateId, toField = toField),
+    )
+    val canSubmit = WorkflowRuleMath.canSubmitDrip(name, stages)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = { onSubmit(name, description, stages) },
+                enabled = canSubmit,
+                modifier = Modifier.testTag(DripSequencesTestTags.CREATE_SUBMIT),
+            ) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("New drip sequence") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Description") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text("First stage", style = MaterialTheme.typography.titleSmall)
+                OutlinedTextField(
+                    value = templateId,
+                    onValueChange = { templateId = it },
+                    label = { Text("Template id") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = toField,
+                    onValueChange = { toField = it },
+                    label = { Text("To field") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = delayHoursText,
+                    onValueChange = { delayHoursText = it.filter(Char::isDigit) },
+                    label = { Text("Delay (hours)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRuleDomain.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRuleDomain.kt
@@ -1,0 +1,120 @@
+package com.testlogon.android.feature.workflow
+
+import com.testlogon.android.core.network.workflow.DripSequenceCreateRequest
+import com.testlogon.android.core.network.workflow.DripSequenceDto
+import com.testlogon.android.core.network.workflow.DripStageDto
+import com.testlogon.android.core.network.workflow.WorkflowRuleCreateRequest
+import com.testlogon.android.core.network.workflow.WorkflowRunDto
+import java.time.Instant
+
+/**
+ * WFL — extra feature domain (run history + drip sequences) + DTO mappers + request builders for the
+ * SuiteCRM Workflow admin CRUD. Android-free + JVM-testable. Complements [WorkflowRule] in
+ * WorkflowRuleModel.kt (the shared epoch->Instant helper is duplicated privately to keep files decoupled).
+ */
+
+private fun epochOrNull(sec: Long?): Instant? =
+    sec?.takeIf { it > 0 }?.let { Instant.ofEpochSecond(it) }
+
+// ---------------------------------------------------------------------------
+// Run history
+// ---------------------------------------------------------------------------
+
+/** One rule-run history entry (mapped from [WorkflowRunDto]). */
+data class WorkflowRun(
+    val runId: String,
+    val ruleId: String,
+    val targetModule: WorkflowTargetModule = WorkflowTargetModule.UNKNOWN,
+    val recordId: String = "",
+    val triggerType: WorkflowTriggerType = WorkflowTriggerType.UNKNOWN,
+    val outcome: RunOutcome = RunOutcome.UNKNOWN,
+    val actionsFiredCount: Int = 0,
+    val startedAt: Instant? = null,
+    val finishedAt: Instant? = null,
+    val errorMessage: String? = null,
+)
+
+/** Maps a transport run to the feature domain. */
+fun WorkflowRunDto.toDomain(): WorkflowRun = WorkflowRun(
+    runId = runId,
+    ruleId = ruleId,
+    targetModule = WorkflowTargetModule.fromToken(targetModule),
+    recordId = recordId,
+    triggerType = WorkflowTriggerType.fromToken(triggerType),
+    outcome = WorkflowRuleMath.outcomeOf(outcome),
+    actionsFiredCount = actionsFired.size,
+    startedAt = epochOrNull(startedAt),
+    finishedAt = epochOrNull(finishedAt),
+    errorMessage = errorMessage?.takeIf { it.isNotBlank() },
+)
+
+// ---------------------------------------------------------------------------
+// Drip sequences
+// ---------------------------------------------------------------------------
+
+/** One drip-sequence stage (domain form; used by the create form + list display). */
+data class DripStage(
+    val stageNumber: Int,
+    val delayHours: Int,
+    val templateId: String,
+    val toField: String,
+)
+
+/** One drip sequence (mapped from [DripSequenceDto]). */
+data class DripSequence(
+    val sequenceId: String,
+    val name: String,
+    val description: String = "",
+    val stageCount: Int = 0,
+    val createdBy: String = "",
+    val createdAt: Instant? = null,
+    val updatedAt: Instant? = null,
+)
+
+/** Maps a transport drip sequence to the feature domain (counting stages, not carrying raw payloads). */
+fun DripSequenceDto.toDomain(): DripSequence = DripSequence(
+    sequenceId = sequenceId,
+    name = name,
+    description = description,
+    stageCount = stages.size,
+    createdBy = createdBy,
+    createdAt = epochOrNull(createdAt),
+    updatedAt = epochOrNull(updatedAt),
+)
+
+// ---------------------------------------------------------------------------
+// Request builders (domain -> transport). Kept PURE so they are unit-tested.
+// ---------------------------------------------------------------------------
+
+/** Builds the minimal create request for a rule (no conditions/actions from the lightweight form). */
+fun buildRuleCreateRequest(
+    name: String,
+    description: String,
+    targetModule: WorkflowTargetModule,
+    triggerType: WorkflowTriggerType,
+    enabled: Boolean,
+): WorkflowRuleCreateRequest = WorkflowRuleCreateRequest(
+    name = name.trim(),
+    description = description.trim(),
+    targetModule = targetModule.token,
+    triggerType = triggerType.token,
+    enabled = enabled,
+)
+
+/** Builds the create request for a drip sequence from domain stages. */
+fun buildDripCreateRequest(
+    name: String,
+    description: String,
+    stages: List<DripStage>,
+): DripSequenceCreateRequest = DripSequenceCreateRequest(
+    name = name.trim(),
+    description = description.trim(),
+    stages = stages.map {
+        DripStageDto(
+            stageNumber = it.stageNumber,
+            delayHours = it.delayHours,
+            templateId = it.templateId.trim(),
+            toField = it.toField.trim(),
+        )
+    },
+)

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRuleMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRuleMath.kt
@@ -1,0 +1,113 @@
+package com.testlogon.android.feature.workflow
+
+/**
+ * WFL — PURE rule-state + enable-gating + create-form validation logic for the SuiteCRM Workflow admin.
+ * Android-free + JVM-testable. No I/O, no framework types.
+ *
+ * Mirrors the web constant lists in frontend/src/api/endpoints/crmWorkflow.ts
+ * (WORKFLOW_TARGET_MODULES / WORKFLOW_TRIGGER_TYPES / WORKFLOW_OPERATORS / WORKFLOW_ACTION_TYPES) and the
+ * backend validation in app/services/workflow_rules.py.
+ */
+object WorkflowRuleMath {
+
+    /** Selectable target modules for the create form (mirrors WORKFLOW_TARGET_MODULES, real ones only). */
+    val TARGET_MODULES: List<WorkflowTargetModule> = listOf(
+        WorkflowTargetModule.TICKET,
+        WorkflowTargetModule.CONTACT,
+        WorkflowTargetModule.ORDER,
+        WorkflowTargetModule.SUBSCRIPTION,
+        WorkflowTargetModule.LEAD,
+    )
+
+    /** Selectable trigger types for the create form (mirrors WORKFLOW_TRIGGER_TYPES, real ones only). */
+    val TRIGGER_TYPES: List<WorkflowTriggerType> = listOf(
+        WorkflowTriggerType.ON_SAVE,
+        WorkflowTriggerType.ON_SCHEDULE,
+        WorkflowTriggerType.ON_TIME_ELAPSED,
+    )
+
+    /** Condition operators (mirrors WORKFLOW_OPERATORS). */
+    val OPERATORS: List<String> = listOf(
+        "eq", "neq", "contains", "gt", "lt", "is_empty", "is_not_empty",
+    )
+
+    /** Action types (mirrors WORKFLOW_ACTION_TYPES). */
+    val ACTION_TYPES: List<String> = listOf(
+        "modify_field", "create_record", "send_email", "drip_sequence",
+    )
+
+    /**
+     * The label + intent for the enable/disable toggle of a rule. Enabled rules offer "Disable";
+     * disabled rules offer "Enable". PURE — drives the row action button.
+     */
+    fun toggleLabel(enabled: Boolean): String = if (enabled) "Disable" else "Enable"
+
+    /**
+     * Whether the enable/disable toggle should be shown for a rule. A rule with NO actions can be created
+     * but firing it is a no-op; we still allow the toggle (backend permits it) but callers may warn. This
+     * returns the *target* enabled state after a toggle.
+     */
+    fun nextEnabledState(current: Boolean): Boolean = !current
+
+    /**
+     * PURE create-form validation. Mirrors the backend's required-field checks (name non-blank; a real
+     * target module + trigger type must be chosen). Returns the list of human-readable problems; empty ==
+     * ready to submit.
+     */
+    fun validateCreate(
+        name: String,
+        targetModule: WorkflowTargetModule?,
+        triggerType: WorkflowTriggerType?,
+    ): List<String> {
+        val problems = mutableListOf<String>()
+        if (name.isBlank()) problems += "Name is required."
+        if (targetModule == null || targetModule == WorkflowTargetModule.UNKNOWN) {
+            problems += "Pick a target module."
+        }
+        if (triggerType == null || triggerType == WorkflowTriggerType.UNKNOWN) {
+            problems += "Pick a trigger type."
+        }
+        return problems
+    }
+
+    /** Convenience: is the create form submittable? */
+    fun canSubmitCreate(
+        name: String,
+        targetModule: WorkflowTargetModule?,
+        triggerType: WorkflowTriggerType?,
+    ): Boolean = validateCreate(name, targetModule, triggerType).isEmpty()
+
+    /**
+     * PURE drip-sequence create validation. Mirrors app/services/workflow_drip_sequences.py: name
+     * non-blank and at least one stage, each stage needs a template id and a non-negative delay. Returns
+     * the problems; empty == ready.
+     */
+    fun validateDripCreate(name: String, stages: List<DripStage>): List<String> {
+        val problems = mutableListOf<String>()
+        if (name.isBlank()) problems += "Name is required."
+        if (stages.isEmpty()) problems += "Add at least one stage."
+        stages.forEachIndexed { i, s ->
+            if (s.templateId.isBlank()) problems += "Stage ${i + 1}: template id is required."
+            if (s.delayHours < 0) problems += "Stage ${i + 1}: delay can't be negative."
+        }
+        return problems
+    }
+
+    /** Convenience: is the drip create form submittable? */
+    fun canSubmitDrip(name: String, stages: List<DripStage>): Boolean =
+        validateDripCreate(name, stages).isEmpty()
+
+    /**
+     * PURE outcome bucketing for run history rows: normalizes the free-form `outcome` string into a small
+     * closed set for display / colouring. Unknown values fall back to [RunOutcome.UNKNOWN].
+     */
+    fun outcomeOf(raw: String?): RunOutcome = when (raw?.lowercase()) {
+        "matched" -> RunOutcome.MATCHED
+        "error" -> RunOutcome.ERROR
+        "skipped" -> RunOutcome.SKIPPED
+        else -> RunOutcome.UNKNOWN
+    }
+}
+
+/** Closed set of run outcomes for display. */
+enum class RunOutcome { MATCHED, ERROR, SKIPPED, UNKNOWN }

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesRepository.kt
@@ -4,6 +4,9 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonEncodingException
 import com.testlogon.android.core.model.ApiResult
 import com.testlogon.android.core.network.error.ApiErrorParser
+import com.testlogon.android.core.network.workflow.DripSequenceCreateRequest
+import com.testlogon.android.core.network.workflow.WorkflowRuleCreateRequest
+import com.testlogon.android.core.network.workflow.WorkflowRuleUpdateRequest
 import com.testlogon.android.core.network.workflow.WorkflowRulesApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -15,14 +18,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * WFL — data layer for the SuiteCRM Workflow admin list/read MVP.
+ * WFL — data layer for the SuiteCRM Workflow admin CRUD.
  *
  * REUSES the core-network [WorkflowRulesApi] + shared [ApiErrorParser]; maps DTOs to domain BEFORE the
  * typed [ApiResult]. DEGRADE-ON-404: the whole router 404s when CRM_WORKFLOW_ENABLED is off (or 403 for
  * non-admins); both surface as an [ApiResult.Failure] the ViewModel folds to a calm unavailable state.
  *
- * READ ONLY: create/update/delete/enable/disable + drip sequences + run history are intentionally out of
- * scope for the MVP (mutations are admin-heavy and the web surfaces them separately).
+ * Full admin surface: list/read + create/update/delete/enable/disable + run history + drip-sequence
+ * list/create. Mutations require admin/root + CSRF server-side (attached globally by the interceptors).
  */
 interface WorkflowRulesRepository {
 
@@ -31,6 +34,30 @@ interface WorkflowRulesRepository {
 
     /** Read one rule's detail. */
     suspend fun getRule(ruleId: String): ApiResult<WorkflowRule>
+
+    /** Create a workflow rule. */
+    suspend fun createRule(body: WorkflowRuleCreateRequest): ApiResult<WorkflowRule>
+
+    /** Patch a rule (partial update; only non-null fields are sent). */
+    suspend fun updateRule(ruleId: String, body: WorkflowRuleUpdateRequest): ApiResult<WorkflowRule>
+
+    /** Delete a rule. */
+    suspend fun deleteRule(ruleId: String): ApiResult<Unit>
+
+    /** Enable a rule (returns the updated rule). */
+    suspend fun enableRule(ruleId: String): ApiResult<WorkflowRule>
+
+    /** Disable a rule (returns the updated rule). */
+    suspend fun disableRule(ruleId: String): ApiResult<WorkflowRule>
+
+    /** List a rule's run history (most-recent first, cursor-paged server-side). */
+    suspend fun listRuleRuns(ruleId: String, limit: Int? = null): ApiResult<List<WorkflowRun>>
+
+    /** List drip sequences. */
+    suspend fun listDripSequences(limit: Int? = null): ApiResult<List<DripSequence>>
+
+    /** Create a drip sequence. */
+    suspend fun createDripSequence(body: DripSequenceCreateRequest): ApiResult<DripSequence>
 }
 
 @Singleton
@@ -48,6 +75,39 @@ class WorkflowRulesRepositoryImpl @Inject constructor(
 
     override suspend fun getRule(ruleId: String): ApiResult<WorkflowRule> =
         withContext(Dispatchers.IO) { call { api.getRule(ruleId).toDomain() } }
+
+    override suspend fun createRule(body: WorkflowRuleCreateRequest): ApiResult<WorkflowRule> =
+        withContext(Dispatchers.IO) { call { api.createRule(body).toDomain() } }
+
+    override suspend fun updateRule(
+        ruleId: String,
+        body: WorkflowRuleUpdateRequest,
+    ): ApiResult<WorkflowRule> =
+        withContext(Dispatchers.IO) { call { api.updateRule(ruleId, body).toDomain() } }
+
+    override suspend fun deleteRule(ruleId: String): ApiResult<Unit> =
+        withContext(Dispatchers.IO) { call { api.deleteRule(ruleId) } }
+
+    override suspend fun enableRule(ruleId: String): ApiResult<WorkflowRule> =
+        withContext(Dispatchers.IO) { call { api.enableRule(ruleId).toDomain() } }
+
+    override suspend fun disableRule(ruleId: String): ApiResult<WorkflowRule> =
+        withContext(Dispatchers.IO) { call { api.disableRule(ruleId).toDomain() } }
+
+    override suspend fun listRuleRuns(ruleId: String, limit: Int?): ApiResult<List<WorkflowRun>> =
+        withContext(Dispatchers.IO) {
+            call { api.listRuleRuns(ruleId, limit = limit).runs.map { it.toDomain() } }
+        }
+
+    override suspend fun listDripSequences(limit: Int?): ApiResult<List<DripSequence>> =
+        withContext(Dispatchers.IO) {
+            call { api.listDripSequences(limit = limit).sequences.map { it.toDomain() } }
+        }
+
+    override suspend fun createDripSequence(
+        body: DripSequenceCreateRequest,
+    ): ApiResult<DripSequence> =
+        withContext(Dispatchers.IO) { call { api.createDripSequence(body).toDomain() } }
 
     /** Folds a block into [ApiResult]; mirrors SignatureRepositoryImpl.call. */
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = try {

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesScreen.kt
@@ -14,20 +14,36 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -35,17 +51,25 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
-/** WFL — stable testTags for the workflow-rules admin list screen. */
+/** WFL — stable testTags for the workflow-rules admin surface. */
 object WorkflowRulesTestTags {
     const val SCREEN = "workflow_rules_screen"
     const val RETRY = "workflow_rules_retry"
+    const val FAB_CREATE = "workflow_rules_fab_create"
+    const val DRIP_ENTRY = "workflow_rules_drip_entry"
+    const val CREATE_SUBMIT = "workflow_rule_create_submit"
 
     fun row(ruleId: String): String = "workflow_rule_row_$ruleId"
+    fun toggle(ruleId: String): String = "workflow_rule_toggle_$ruleId"
+    fun runs(ruleId: String): String = "workflow_rule_runs_$ruleId"
+    fun delete(ruleId: String): String = "workflow_rule_delete_$ruleId"
 }
 
 @Composable
 fun WorkflowRulesRoute(
     onBack: () -> Unit,
+    onOpenRuns: (String) -> Unit,
+    onOpenDrip: () -> Unit,
     viewModel: WorkflowRulesViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -54,6 +78,12 @@ fun WorkflowRulesRoute(
         onBack = onBack,
         onRefresh = viewModel::refresh,
         onRetry = viewModel::load,
+        onToggle = viewModel::toggleEnabled,
+        onDelete = viewModel::delete,
+        onOpenRuns = onOpenRuns,
+        onOpenDrip = onOpenDrip,
+        onCreate = viewModel::createRule,
+        onMessageShown = viewModel::consumeMessage,
     )
 }
 
@@ -63,9 +93,27 @@ fun WorkflowRulesScreen(
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
+    onToggle: (WorkflowRule) -> Unit,
+    onDelete: (String) -> Unit,
+    onOpenRuns: (String) -> Unit,
+    onOpenDrip: () -> Unit,
+    onCreate: (String, String, WorkflowTargetModule, WorkflowTriggerType, Boolean, () -> Unit) -> Unit,
+    onMessageShown: () -> Unit,
 ) {
+    val snackbar = remember { SnackbarHostState() }
+    var showCreate by rememberSaveable { mutableStateOf(false) }
+
+    val message = (state as? WorkflowRulesUiState.Content)?.message
+    LaunchedEffect(message) {
+        if (message != null) {
+            snackbar.showSnackbar(message)
+            onMessageShown()
+        }
+    }
+
     Scaffold(
         modifier = Modifier.testTag(WorkflowRulesTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbar) },
         topBar = {
             TopAppBar(
                 title = { Text("Workflow rules") },
@@ -74,7 +122,21 @@ fun WorkflowRulesScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
+                actions = {
+                    TextButton(
+                        onClick = onOpenDrip,
+                        modifier = Modifier.testTag(WorkflowRulesTestTags.DRIP_ENTRY),
+                    ) { Text("Drip") }
+                },
             )
+        },
+        floatingActionButton = {
+            if (state is WorkflowRulesUiState.Content || state is WorkflowRulesUiState.Empty) {
+                FloatingActionButton(
+                    onClick = { showCreate = true },
+                    modifier = Modifier.testTag(WorkflowRulesTestTags.FAB_CREATE),
+                ) { Icon(Icons.Filled.Add, contentDescription = "New rule") }
+            }
         },
     ) { padding ->
         Box(Modifier.padding(padding).fillMaxSize()) {
@@ -91,7 +153,7 @@ fun WorkflowRulesScreen(
 
                 is WorkflowRulesUiState.Empty ->
                     Text(
-                        "No workflow rules configured.",
+                        "No workflow rules configured. Tap + to create one.",
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.align(Alignment.Center).padding(24.dp),
                     )
@@ -122,16 +184,39 @@ fun WorkflowRulesScreen(
                                 modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
                             )
                         }
-                        items(state.rules, key = { it.ruleId }) { rule -> RuleRow(rule) }
+                        items(state.rules, key = { it.ruleId }) { rule ->
+                            RuleRow(
+                                rule = rule,
+                                busy = state.busyRuleId == rule.ruleId,
+                                onToggle = { onToggle(rule) },
+                                onRuns = { onOpenRuns(rule.ruleId) },
+                                onDelete = { onDelete(rule.ruleId) },
+                            )
+                        }
                     }
                 }
             }
         }
     }
+
+    if (showCreate) {
+        CreateRuleDialog(
+            onDismiss = { showCreate = false },
+            onSubmit = { name, desc, module, trigger, enabled ->
+                onCreate(name, desc, module, trigger, enabled) { showCreate = false }
+            },
+        )
+    }
 }
 
 @Composable
-private fun RuleRow(rule: WorkflowRule) {
+private fun RuleRow(
+    rule: WorkflowRule,
+    busy: Boolean,
+    onToggle: () -> Unit,
+    onRuns: () -> Unit,
+    onDelete: () -> Unit,
+) {
     Card(
         modifier = Modifier.fillMaxWidth().testTag(WorkflowRulesTestTags.row(rule.ruleId)),
     ) {
@@ -149,11 +234,125 @@ private fun RuleRow(rule: WorkflowRule) {
                 "${rule.conditionCount} conditions • ${rule.actionCount} actions",
                 style = MaterialTheme.typography.bodySmall,
             )
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = onToggle,
+                    enabled = !busy,
+                    modifier = Modifier.testTag(WorkflowRulesTestTags.toggle(rule.ruleId)),
+                ) { Text(WorkflowRuleMath.toggleLabel(rule.enabled)) }
+                OutlinedButton(
+                    onClick = onRuns,
+                    enabled = !busy,
+                    modifier = Modifier.testTag(WorkflowRulesTestTags.runs(rule.ruleId)),
+                ) { Text("Runs") }
+                TextButton(
+                    onClick = onDelete,
+                    enabled = !busy,
+                    modifier = Modifier.testTag(WorkflowRulesTestTags.delete(rule.ruleId)),
+                ) { Text("Delete") }
+            }
         }
     }
 }
 
-private fun moduleLabel(m: WorkflowTargetModule): String = when (m) {
+@Composable
+private fun CreateRuleDialog(
+    onDismiss: () -> Unit,
+    onSubmit: (String, String, WorkflowTargetModule, WorkflowTriggerType, Boolean) -> Unit,
+) {
+    var name by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
+    var module by remember { mutableStateOf(WorkflowTargetModule.TICKET) }
+    var trigger by remember { mutableStateOf(WorkflowTriggerType.ON_SAVE) }
+    var enabled by rememberSaveable { mutableStateOf(false) }
+
+    val canSubmit = WorkflowRuleMath.canSubmitCreate(name, module, trigger)
+
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = { onSubmit(name, description, module, trigger, enabled) },
+                enabled = canSubmit,
+                modifier = Modifier.testTag(WorkflowRulesTestTags.CREATE_SUBMIT),
+            ) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        title = { Text("New workflow rule") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Description") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                EnumDropdown(
+                    label = "Target module",
+                    options = WorkflowRuleMath.TARGET_MODULES,
+                    selected = module,
+                    optionLabel = ::moduleLabel,
+                    onSelect = { module = it },
+                )
+                EnumDropdown(
+                    label = "Trigger",
+                    options = WorkflowRuleMath.TRIGGER_TYPES,
+                    selected = trigger,
+                    optionLabel = ::triggerLabel,
+                    onSelect = { trigger = it },
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text("Enabled", style = MaterialTheme.typography.bodyMedium)
+                    Switch(checked = enabled, onCheckedChange = { enabled = it })
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun <T> EnumDropdown(
+    label: String,
+    options: List<T>,
+    selected: T,
+    optionLabel: (T) -> String,
+    onSelect: (T) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = optionLabel(selected),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.fillMaxWidth().menuAnchor(),
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(optionLabel(option)) },
+                    onClick = {
+                        onSelect(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+internal fun moduleLabel(m: WorkflowTargetModule): String = when (m) {
     WorkflowTargetModule.TICKET -> "Ticket"
     WorkflowTargetModule.CONTACT -> "Contact"
     WorkflowTargetModule.ORDER -> "Order"
@@ -162,7 +361,7 @@ private fun moduleLabel(m: WorkflowTargetModule): String = when (m) {
     WorkflowTargetModule.UNKNOWN -> "—"
 }
 
-private fun triggerLabel(t: WorkflowTriggerType): String = when (t) {
+internal fun triggerLabel(t: WorkflowTriggerType): String = when (t) {
     WorkflowTriggerType.ON_SAVE -> "On save"
     WorkflowTriggerType.ON_SCHEDULE -> "On schedule"
     WorkflowTriggerType.ON_TIME_ELAPSED -> "On time elapsed"

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesUiState.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesUiState.kt
@@ -3,7 +3,7 @@ package com.testlogon.android.feature.workflow
 import com.testlogon.android.core.model.ApiError
 
 /**
- * WFL — UI envelope + pure fold for the workflow-rules admin list. Android-free + JVM-testable.
+ * WFL — UI envelopes + pure folds for the workflow-rules admin surface. Android-free + JVM-testable.
  *
  * DEGRADE-ON-404: a 404 (flag off) OR 403 (not admin) folds to [Unavailable] — a calm message, not a
  * scary error/retry. Any other failure with no prior content -> [Error].
@@ -16,6 +16,10 @@ sealed interface WorkflowRulesUiState {
         val rules: List<WorkflowRule>,
         val enabledCount: Int,
         val isRefreshing: Boolean = false,
+        /** A rule id currently being toggled/deleted (disables its row actions). null == idle. */
+        val busyRuleId: String? = null,
+        /** Transient one-shot user message (e.g. "Rule enabled"), cleared by the ViewModel. */
+        val message: String? = null,
     ) : WorkflowRulesUiState
 
     data object Empty : WorkflowRulesUiState
@@ -41,4 +45,50 @@ fun foldRulesResult(
         val sorted = sortRules(rules)
         WorkflowRulesUiState.Content(rules = sorted, enabledCount = enabledCount(sorted))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Run history
+// ---------------------------------------------------------------------------
+
+/** UI envelope for a rule's run-history list. */
+sealed interface WorkflowRunsUiState {
+    data object Loading : WorkflowRunsUiState
+    data class Content(val runs: List<WorkflowRun>) : WorkflowRunsUiState
+    data object Empty : WorkflowRunsUiState
+    data object Unavailable : WorkflowRunsUiState
+    data class Error(val error: ApiError) : WorkflowRunsUiState
+}
+
+/** PURE fold of a run-history load. 404/403 -> [Unavailable]; empty -> [Empty]; else [Content]. */
+fun foldRunsResult(runs: List<WorkflowRun>?, error: ApiError?): WorkflowRunsUiState = when {
+    error != null && (error.status == 404 || error.status == 403) -> WorkflowRunsUiState.Unavailable
+    error != null -> WorkflowRunsUiState.Error(error)
+    runs == null || runs.isEmpty() -> WorkflowRunsUiState.Empty
+    else -> WorkflowRunsUiState.Content(runs.sortedByDescending { it.startedAt })
+}
+
+// ---------------------------------------------------------------------------
+// Drip sequences
+// ---------------------------------------------------------------------------
+
+/** UI envelope for the drip-sequence list. */
+sealed interface DripSequencesUiState {
+    data object Loading : DripSequencesUiState
+    data class Content(
+        val sequences: List<DripSequence>,
+        val isRefreshing: Boolean = false,
+        val message: String? = null,
+    ) : DripSequencesUiState
+    data object Empty : DripSequencesUiState
+    data object Unavailable : DripSequencesUiState
+    data class Error(val error: ApiError) : DripSequencesUiState
+}
+
+/** PURE fold of a drip-sequence load. 404/403 -> [Unavailable]; empty -> [Empty]; else [Content]. */
+fun foldDripResult(sequences: List<DripSequence>?, error: ApiError?): DripSequencesUiState = when {
+    error != null && (error.status == 404 || error.status == 403) -> DripSequencesUiState.Unavailable
+    error != null -> DripSequencesUiState.Error(error)
+    sequences == null || sequences.isEmpty() -> DripSequencesUiState.Empty
+    else -> DripSequencesUiState.Content(sequences.sortedBy { it.name.lowercase() })
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRulesViewModel.kt
@@ -13,8 +13,9 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * WFL — presentation logic for the SuiteCRM Workflow admin list/read MVP. READ ONLY: [load] / [refresh]
- * read the rule list ONCE (no poll loop, no writes). DEGRADE-ON-404/403 handled by [foldRulesResult].
+ * WFL — presentation logic for the SuiteCRM Workflow admin rules list + mutations. [load] / [refresh]
+ * read the rule list; [enable] / [disable] / [delete] mutate then re-read; [createRule] posts a new rule
+ * then re-reads. DEGRADE-ON-404/403 handled by [foldRulesResult]. No poll loop.
  */
 @HiltViewModel
 class WorkflowRulesViewModel @Inject constructor(
@@ -44,11 +45,11 @@ class WorkflowRulesViewModel @Inject constructor(
         fetch(showRefreshing = true)
     }
 
-    private fun fetch(showRefreshing: Boolean) {
+    private fun fetch(showRefreshing: Boolean, message: String? = null) {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
             when (val result = repository.listRules()) {
-                is ApiResult.Success -> _uiState.value = foldRulesResult(result.data, null)
+                is ApiResult.Success -> _uiState.value = applyMessage(foldRulesResult(result.data, null), message)
                 is ApiResult.Failure -> _uiState.value = foldRulesResult(null, result.error)
                 is ApiResult.NetworkError ->
                     _uiState.value =
@@ -57,7 +58,139 @@ class WorkflowRulesViewModel @Inject constructor(
         }
     }
 
+    /** Toggle a rule's enabled state (enable when currently disabled, disable otherwise), then re-read. */
+    fun toggleEnabled(rule: WorkflowRule) {
+        val target = WorkflowRuleMath.nextEnabledState(rule.enabled)
+        setBusy(rule.ruleId)
+        viewModelScope.launch {
+            val result = if (target) repository.enableRule(rule.ruleId) else repository.disableRule(rule.ruleId)
+            afterMutation(result, if (target) "Rule enabled" else "Rule disabled")
+        }
+    }
+
+    /** Delete a rule then re-read. */
+    fun delete(ruleId: String) {
+        setBusy(ruleId)
+        viewModelScope.launch {
+            afterMutation(repository.deleteRule(ruleId), "Rule deleted")
+        }
+    }
+
+    /** Create a rule from the lightweight form, then re-read. onDone is invoked on success. */
+    fun createRule(
+        name: String,
+        description: String,
+        targetModule: WorkflowTargetModule,
+        triggerType: WorkflowTriggerType,
+        enabled: Boolean,
+        onDone: () -> Unit,
+    ) {
+        viewModelScope.launch {
+            val body = buildRuleCreateRequest(name, description, targetModule, triggerType, enabled)
+            when (repository.createRule(body)) {
+                is ApiResult.Success -> {
+                    onDone()
+                    fetch(showRefreshing = false, message = "Rule created")
+                }
+                is ApiResult.Failure, is ApiResult.NetworkError -> onDone()
+            }
+        }
+    }
+
+    fun consumeMessage() {
+        (_uiState.value as? WorkflowRulesUiState.Content)?.let {
+            if (it.message != null) _uiState.value = it.copy(message = null)
+        }
+    }
+
+    private fun setBusy(ruleId: String?) {
+        (_uiState.value as? WorkflowRulesUiState.Content)?.let {
+            _uiState.value = it.copy(busyRuleId = ruleId)
+        }
+    }
+
+    private fun afterMutation(result: ApiResult<*>, successMessage: String) {
+        when (result) {
+            is ApiResult.Success -> fetch(showRefreshing = false, message = successMessage)
+            is ApiResult.Failure, is ApiResult.NetworkError -> setBusy(null)
+        }
+    }
+
+    private fun applyMessage(state: WorkflowRulesUiState, message: String?): WorkflowRulesUiState =
+        if (message != null && state is WorkflowRulesUiState.Content) state.copy(message = message) else state
+
     private companion object {
         const val NETWORK_MESSAGE = "Couldn't reach the server. Try again."
     }
+}
+
+/** WFL — presentation logic for a single rule's run history (read-only). */
+@HiltViewModel
+class WorkflowRunsViewModel @Inject constructor(
+    private val repository: WorkflowRulesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<WorkflowRunsUiState>(WorkflowRunsUiState.Loading)
+    val uiState: StateFlow<WorkflowRunsUiState> = _uiState.asStateFlow()
+
+    fun load(ruleId: String) {
+        _uiState.value = WorkflowRunsUiState.Loading
+        viewModelScope.launch {
+            _uiState.value = when (val result = repository.listRuleRuns(ruleId)) {
+                is ApiResult.Success -> foldRunsResult(result.data, null)
+                is ApiResult.Failure -> foldRunsResult(null, result.error)
+                is ApiResult.NetworkError ->
+                    foldRunsResult(null, ApiError(ApiError.STATUS_NETWORK, "Couldn't reach the server."))
+            }
+        }
+    }
+}
+
+/** WFL — presentation logic for the drip-sequence list + create. */
+@HiltViewModel
+class DripSequencesViewModel @Inject constructor(
+    private val repository: WorkflowRulesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<DripSequencesUiState>(DripSequencesUiState.Loading)
+    val uiState: StateFlow<DripSequencesUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load(message: String? = null) {
+        if (_uiState.value !is DripSequencesUiState.Content) {
+            _uiState.value = DripSequencesUiState.Loading
+        }
+        viewModelScope.launch {
+            _uiState.value = when (val result = repository.listDripSequences()) {
+                is ApiResult.Success -> applyMessage(foldDripResult(result.data, null), message)
+                is ApiResult.Failure -> foldDripResult(null, result.error)
+                is ApiResult.NetworkError ->
+                    foldDripResult(null, ApiError(ApiError.STATUS_NETWORK, "Couldn't reach the server."))
+            }
+        }
+    }
+
+    fun createSequence(name: String, description: String, stages: List<DripStage>, onDone: () -> Unit) {
+        viewModelScope.launch {
+            when (repository.createDripSequence(buildDripCreateRequest(name, description, stages))) {
+                is ApiResult.Success -> {
+                    onDone()
+                    load(message = "Drip sequence created")
+                }
+                is ApiResult.Failure, is ApiResult.NetworkError -> onDone()
+            }
+        }
+    }
+
+    fun consumeMessage() {
+        (_uiState.value as? DripSequencesUiState.Content)?.let {
+            if (it.message != null) _uiState.value = it.copy(message = null)
+        }
+    }
+
+    private fun applyMessage(state: DripSequencesUiState, message: String?): DripSequencesUiState =
+        if (message != null && state is DripSequencesUiState.Content) state.copy(message = message) else state
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRunsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/workflow/WorkflowRunsScreen.kt
@@ -1,0 +1,136 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.workflow
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/** WFL — stable testTags for the run-history screen. */
+object WorkflowRunsTestTags {
+    const val SCREEN = "workflow_runs_screen"
+    fun row(runId: String): String = "workflow_run_row_$runId"
+}
+
+@Composable
+fun WorkflowRunsRoute(
+    ruleId: String,
+    onBack: () -> Unit,
+    viewModel: WorkflowRunsViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(ruleId) { viewModel.load(ruleId) }
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    WorkflowRunsScreen(state = state, onBack = onBack)
+}
+
+@Composable
+fun WorkflowRunsScreen(state: WorkflowRunsUiState, onBack: () -> Unit) {
+    Scaffold(
+        modifier = Modifier.testTag(WorkflowRunsTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text("Run history") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when (state) {
+                is WorkflowRunsUiState.Loading ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                is WorkflowRunsUiState.Unavailable ->
+                    CenterText("Run history isn't available.")
+
+                is WorkflowRunsUiState.Empty ->
+                    CenterText("No runs recorded for this rule yet.")
+
+                is WorkflowRunsUiState.Error ->
+                    CenterText(state.error.message)
+
+                is WorkflowRunsUiState.Content -> LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(state.runs, key = { it.runId }) { run -> RunRow(run) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RunRow(run: WorkflowRun) {
+    Card(modifier = Modifier.fillMaxWidth().testTag(WorkflowRunsTestTags.row(run.runId))) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(outcomeLabel(run.outcome), style = MaterialTheme.typography.titleMedium)
+            Text(
+                "${moduleLabel(run.targetModule)} • ${triggerLabel(run.triggerType)}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            run.startedAt?.let {
+                Text(
+                    "Started ${FORMATTER.format(it.atZone(ZoneId.systemDefault()))}",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Text("${run.actionsFiredCount} actions fired", style = MaterialTheme.typography.bodySmall)
+            run.errorMessage?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+private val FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM d, HH:mm")
+
+private fun outcomeLabel(o: RunOutcome): String = when (o) {
+    RunOutcome.MATCHED -> "Matched"
+    RunOutcome.ERROR -> "Error"
+    RunOutcome.SKIPPED -> "Skipped"
+    RunOutcome.UNKNOWN -> "—"
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.BoxScope.CenterText(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/WorkflowNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/WorkflowNavigation.kt
@@ -2,21 +2,53 @@ package com.testlogon.android.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.testlogon.android.feature.workflow.DripSequencesRoute
 import com.testlogon.android.feature.workflow.WorkflowRulesRoute
+import com.testlogon.android.feature.workflow.WorkflowRunsRoute
 
 /**
- * WFL — the SuiteCRM Workflow admin destination (reached from the More hub, operator-only). Mirrors web
- * /ui/admin/crm/workflow. Read-only list of workflow rules; degrades to an "unavailable" state when the
- * CRM_WORKFLOW_ENABLED flag is off (404) or the caller is not an admin (403).
+ * WFL — the SuiteCRM Workflow admin destinations (reached from the More hub, operator-only). Mirrors web
+ * /ui/admin/crm/workflow. The rules list is the hub entry (registered in MoreRoutes); the run-history and
+ * drip-sequence destinations are internal sub-routes navigated to from the list (they are NOT separate
+ * More-hub entries, so no new MoreRoutes literal is added). Everything degrades to an "unavailable" state
+ * when CRM_WORKFLOW_ENABLED is off (404) or the caller is not an admin (403).
  */
 data object WorkflowRulesDest {
     const val ROUTE = "admin/crm/workflow/rules"
 }
 
-/** Registers the workflow-rules admin destination. */
+/** Internal sub-route: run history for one rule. */
+data object WorkflowRunsDest {
+    const val ARG_RULE_ID = "ruleId"
+    const val ROUTE = "admin/crm/workflow/rules/{$ARG_RULE_ID}/runs"
+    fun route(ruleId: String): String = "admin/crm/workflow/rules/$ruleId/runs"
+}
+
+/** Internal sub-route: drip-sequence list + create. */
+data object WorkflowDripDest {
+    const val ROUTE = "admin/crm/workflow/drip-sequences"
+}
+
+/** Registers the workflow-rules admin destination + its internal sub-destinations. */
 fun NavGraphBuilder.workflowRulesDestination(navController: NavHostController) {
     composable(WorkflowRulesDest.ROUTE) {
-        WorkflowRulesRoute(onBack = { navController.popBackStack() })
+        WorkflowRulesRoute(
+            onBack = { navController.popBackStack() },
+            onOpenRuns = { ruleId -> navController.navigate(WorkflowRunsDest.route(ruleId)) },
+            onOpenDrip = { navController.navigate(WorkflowDripDest.ROUTE) },
+        )
+    }
+    composable(
+        route = WorkflowRunsDest.ROUTE,
+        arguments = listOf(navArgument(WorkflowRunsDest.ARG_RULE_ID) { type = NavType.StringType }),
+    ) { backStackEntry ->
+        val ruleId = backStackEntry.arguments?.getString(WorkflowRunsDest.ARG_RULE_ID).orEmpty()
+        WorkflowRunsRoute(ruleId = ruleId, onBack = { navController.popBackStack() })
+    }
+    composable(WorkflowDripDest.ROUTE) {
+        DripSequencesRoute(onBack = { navController.popBackStack() })
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/feature/workflow/WorkflowRuleMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/feature/workflow/WorkflowRuleMathTest.kt
@@ -1,0 +1,207 @@
+package com.testlogon.android.feature.workflow
+
+import com.testlogon.android.core.model.ApiError
+import com.testlogon.android.core.network.workflow.DripSequenceDto
+import com.testlogon.android.core.network.workflow.WorkflowRunDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * WFL — pure tests for the workflow admin CRUD extension: enable-gating + create-form validation
+ * (WorkflowRuleMath), run + drip mappers, request builders, and the runs/drip folds (degrade on 404/403).
+ */
+class WorkflowRuleMathTest {
+
+    // ----- toggle / enable gating -----
+
+    @Test
+    fun toggleLabel_reflectsCurrentState() {
+        assertEquals("Disable", WorkflowRuleMath.toggleLabel(enabled = true))
+        assertEquals("Enable", WorkflowRuleMath.toggleLabel(enabled = false))
+    }
+
+    @Test
+    fun nextEnabledState_flips() {
+        assertTrue(WorkflowRuleMath.nextEnabledState(false))
+        assertFalse(WorkflowRuleMath.nextEnabledState(true))
+    }
+
+    // ----- create validation -----
+
+    @Test
+    fun validateCreate_blankName_reportsProblem() {
+        val problems = WorkflowRuleMath.validateCreate(
+            name = "  ",
+            targetModule = WorkflowTargetModule.TICKET,
+            triggerType = WorkflowTriggerType.ON_SAVE,
+        )
+        assertEquals(listOf("Name is required."), problems)
+    }
+
+    @Test
+    fun validateCreate_unknownModuleAndTrigger_reportBoth() {
+        val problems = WorkflowRuleMath.validateCreate(
+            name = "Escalate",
+            targetModule = WorkflowTargetModule.UNKNOWN,
+            triggerType = null,
+        )
+        assertEquals(2, problems.size)
+    }
+
+    @Test
+    fun canSubmitCreate_validForm_true() {
+        assertTrue(
+            WorkflowRuleMath.canSubmitCreate(
+                name = "Escalate",
+                targetModule = WorkflowTargetModule.CONTACT,
+                triggerType = WorkflowTriggerType.ON_SCHEDULE,
+            ),
+        )
+    }
+
+    // ----- drip validation -----
+
+    @Test
+    fun validateDripCreate_emptyStages_reportsProblem() {
+        val problems = WorkflowRuleMath.validateDripCreate("Welcome", emptyList())
+        assertTrue(problems.contains("Add at least one stage."))
+    }
+
+    @Test
+    fun validateDripCreate_badStage_reportsTemplateAndDelay() {
+        val problems = WorkflowRuleMath.validateDripCreate(
+            "Welcome",
+            listOf(DripStage(stageNumber = 1, delayHours = -5, templateId = "", toField = "email")),
+        )
+        assertTrue(problems.any { it.contains("template id") })
+        assertTrue(problems.any { it.contains("delay") })
+    }
+
+    @Test
+    fun canSubmitDrip_validForm_true() {
+        assertTrue(
+            WorkflowRuleMath.canSubmitDrip(
+                "Welcome",
+                listOf(DripStage(1, 24, "tmpl_1", "email")),
+            ),
+        )
+    }
+
+    // ----- outcome bucketing -----
+
+    @Test
+    fun outcomeOf_mapsKnownValues_andFallsBack() {
+        assertEquals(RunOutcome.MATCHED, WorkflowRuleMath.outcomeOf("matched"))
+        assertEquals(RunOutcome.ERROR, WorkflowRuleMath.outcomeOf("ERROR"))
+        assertEquals(RunOutcome.SKIPPED, WorkflowRuleMath.outcomeOf("skipped"))
+        assertEquals(RunOutcome.UNKNOWN, WorkflowRuleMath.outcomeOf("weird"))
+        assertEquals(RunOutcome.UNKNOWN, WorkflowRuleMath.outcomeOf(null))
+    }
+
+    // ----- run mapper -----
+
+    @Test
+    fun runDtoMapper_countsActions_bucketsOutcome_dropsZeroTimestamps() {
+        val dto = WorkflowRunDto(
+            runId = "run1",
+            ruleId = "r1",
+            targetModule = "ticket",
+            triggerType = "on_save",
+            outcome = "matched",
+            actionsFired = listOf(mapOf("a" to 1), mapOf("b" to 2)),
+            startedAt = 1_700_000_000,
+            finishedAt = 0,
+            errorMessage = "  ",
+        )
+        val d = dto.toDomain()
+        assertEquals(RunOutcome.MATCHED, d.outcome)
+        assertEquals(2, d.actionsFiredCount)
+        assertEquals(WorkflowTargetModule.TICKET, d.targetModule)
+        assertTrue(d.startedAt != null)
+        assertEquals(null, d.finishedAt)
+        assertEquals(null, d.errorMessage)
+    }
+
+    // ----- drip mapper -----
+
+    @Test
+    fun dripDtoMapper_countsStages() {
+        val dto = DripSequenceDto(
+            sequenceId = "seq1",
+            name = "Welcome",
+            stages = listOf(mapOf("s" to 1), mapOf("s" to 2), mapOf("s" to 3)),
+            createdAt = 1_700_000_000,
+            updatedAt = 1_700_000_500,
+        )
+        val d = dto.toDomain()
+        assertEquals(3, d.stageCount)
+        assertTrue(d.createdAt != null)
+    }
+
+    // ----- request builders -----
+
+    @Test
+    fun buildRuleCreateRequest_trimsAndMapsTokens() {
+        val req = buildRuleCreateRequest(
+            name = "  Escalate  ",
+            description = " urgent ",
+            targetModule = WorkflowTargetModule.ORDER,
+            triggerType = WorkflowTriggerType.ON_TIME_ELAPSED,
+            enabled = true,
+        )
+        assertEquals("Escalate", req.name)
+        assertEquals("urgent", req.description)
+        assertEquals("order", req.targetModule)
+        assertEquals("on_time_elapsed", req.triggerType)
+        assertTrue(req.enabled)
+    }
+
+    @Test
+    fun buildDripCreateRequest_trimsStageFields() {
+        val req = buildDripCreateRequest(
+            name = " Welcome ",
+            description = "",
+            stages = listOf(DripStage(1, 24, "  tmpl_1  ", " email ")),
+        )
+        assertEquals("Welcome", req.name)
+        assertEquals(1, req.stages.size)
+        assertEquals("tmpl_1", req.stages.first().templateId)
+        assertEquals("email", req.stages.first().toField)
+    }
+
+    // ----- folds -----
+
+    @Test
+    fun foldRunsResult_degradesOn404and403() {
+        assertEquals(WorkflowRunsUiState.Unavailable, foldRunsResult(null, ApiError(404, "x")))
+        assertEquals(WorkflowRunsUiState.Unavailable, foldRunsResult(null, ApiError(403, "x")))
+        assertTrue(foldRunsResult(null, ApiError(500, "x")) is WorkflowRunsUiState.Error)
+        assertEquals(WorkflowRunsUiState.Empty, foldRunsResult(emptyList(), null))
+    }
+
+    @Test
+    fun foldRunsResult_sortsByStartedAtDescending() {
+        val a = WorkflowRun(runId = "a", ruleId = "r", startedAt = java.time.Instant.ofEpochSecond(100))
+        val b = WorkflowRun(runId = "b", ruleId = "r", startedAt = java.time.Instant.ofEpochSecond(200))
+        val state = foldRunsResult(listOf(a, b), null)
+        assertTrue(state is WorkflowRunsUiState.Content)
+        assertEquals("b", (state as WorkflowRunsUiState.Content).runs.first().runId)
+    }
+
+    @Test
+    fun foldDripResult_degradesAndSortsByName() {
+        assertEquals(DripSequencesUiState.Unavailable, foldDripResult(null, ApiError(404, "x")))
+        assertEquals(DripSequencesUiState.Empty, foldDripResult(emptyList(), null))
+        val state = foldDripResult(
+            listOf(
+                DripSequence(sequenceId = "1", name = "Zeta"),
+                DripSequence(sequenceId = "2", name = "alpha"),
+            ),
+            null,
+        )
+        assertTrue(state is DripSequencesUiState.Content)
+        assertEquals("2", (state as DripSequencesUiState.Content).sequences.first().sequenceId)
+    }
+}

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRuleDtos.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRuleDtos.kt
@@ -3,18 +3,19 @@ package com.testlogon.android.core.network.workflow
 import com.squareup.moshi.Json
 
 /**
- * Transport DTOs for the SuiteCRM Workflow (WFL) admin surface — READ subset.
+ * Transport DTOs for the SuiteCRM Workflow (WFL) admin surface — READ + WRITE.
  *
  * Backend router: app/routers/workflow_rules.py (prefix /ui/admin/crm/workflow).
  * Gated by CRM_WORKFLOW_ENABLED (default OFF -> 404); the repository degrades on 404.
  *
- * Mirrors frontend/src/api/endpoints/crmWorkflow.ts (WorkflowRuleOut / WorkflowRuleListOut). The Android
- * MVP is list/read only, so only the read shapes are ported (create/update/delete/enable/disable + drip
- * sequences + run history are intentionally NOT ported — see repository KDoc).
+ * Mirrors frontend/src/api/endpoints/crmWorkflow.ts (WorkflowRule* / WorkflowRun* / DripSequence*). The
+ * full admin CRUD is ported: list/read, create (POST /rules), update (PATCH /rules/{id}), delete, enable,
+ * disable, run history (GET /rules/{id}/runs), and drip-sequence CRUD (GET/POST/GET/PATCH/DELETE
+ * /drip-sequences).
  *
  * CODEGEN NOTE: reflective Moshi factory -> explicit @Json(name=...) on every key. The loosely-typed
- * config / conditions / actions payloads are Map / List<Map> of String -> Any? with @JvmSuppressWildcards
- * to keep Moshi's generic resolution happy. Timestamps are Unix-second Longs.
+ * config / conditions / actions / stages payloads are Map / List<Map> of String -> Any? with
+ * @JvmSuppressWildcards to keep Moshi's generic resolution happy. Timestamps are Unix-second Longs.
  */
 
 /** One workflow rule (mirrors WorkflowRuleOut). `rule_id` + `name` are required. */
@@ -40,4 +41,116 @@ data class WorkflowRuleDto(
 data class WorkflowRuleListDto(
     @Json(name = "rules") val rules: List<WorkflowRuleDto> = emptyList(),
     @Json(name = "cursor") val cursor: String? = null,
+)
+
+// ---------------------------------------------------------------------------
+// Write requests (mirror WorkflowRuleCreateIn / WorkflowRuleUpdateIn)
+// ---------------------------------------------------------------------------
+
+/** A single rule condition (mirrors WorkflowConditionIn). `value` is optional/nullable. */
+data class WorkflowConditionDto(
+    @Json(name = "field") val field: String,
+    @Json(name = "operator") val operator: String,
+    @Json(name = "value") val value: String? = null,
+)
+
+/** A single rule action (mirrors WorkflowActionIn). `config` is a loosely-typed map. */
+data class WorkflowActionDto(
+    @Json(name = "action_type") val actionType: String,
+    @Json(name = "config") val config: Map<String, @JvmSuppressWildcards Any?> = emptyMap(),
+)
+
+/** Create body for POST /rules (mirrors WorkflowRuleCreateIn). */
+data class WorkflowRuleCreateRequest(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String = "",
+    @Json(name = "target_module") val targetModule: String,
+    @Json(name = "trigger_type") val triggerType: String,
+    @Json(name = "trigger_config")
+    val triggerConfig: Map<String, @JvmSuppressWildcards Any?> = emptyMap(),
+    @Json(name = "conditions") val conditions: List<WorkflowConditionDto> = emptyList(),
+    @Json(name = "actions") val actions: List<WorkflowActionDto> = emptyList(),
+    @Json(name = "enabled") val enabled: Boolean = false,
+)
+
+/**
+ * Update body for PATCH /rules/{id} (mirrors WorkflowRuleUpdateIn). Backend uses exclude_unset so only
+ * non-null fields are sent; Moshi's `serializeNulls` is OFF by default, so null fields are omitted.
+ */
+data class WorkflowRuleUpdateRequest(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "trigger_config")
+    val triggerConfig: Map<String, @JvmSuppressWildcards Any?>? = null,
+    @Json(name = "conditions") val conditions: List<WorkflowConditionDto>? = null,
+    @Json(name = "actions") val actions: List<WorkflowActionDto>? = null,
+)
+
+// ---------------------------------------------------------------------------
+// Run history (mirror WorkflowRunOut / WorkflowRunListOut)
+// ---------------------------------------------------------------------------
+
+/** One rule-run history entry (mirrors WorkflowRunOut). */
+data class WorkflowRunDto(
+    @Json(name = "run_id") val runId: String = "",
+    @Json(name = "rule_id") val ruleId: String = "",
+    @Json(name = "target_module") val targetModule: String = "",
+    @Json(name = "record_id") val recordId: String = "",
+    @Json(name = "trigger_type") val triggerType: String = "",
+    @Json(name = "outcome") val outcome: String = "",
+    @Json(name = "actions_fired")
+    val actionsFired: List<Map<String, @JvmSuppressWildcards Any?>> = emptyList(),
+    @Json(name = "started_at") val startedAt: Long = 0,
+    @Json(name = "finished_at") val finishedAt: Long? = null,
+    @Json(name = "error_message") val errorMessage: String? = null,
+)
+
+/** The run-history envelope (mirrors WorkflowRunListOut). */
+data class WorkflowRunListDto(
+    @Json(name = "runs") val runs: List<WorkflowRunDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+// ---------------------------------------------------------------------------
+// Drip sequences (mirror DripSequence* + DripStageIn)
+// ---------------------------------------------------------------------------
+
+/** One drip-sequence stage (mirrors DripStageIn). */
+data class DripStageDto(
+    @Json(name = "stage_number") val stageNumber: Int,
+    @Json(name = "delay_hours") val delayHours: Int,
+    @Json(name = "template_id") val templateId: String,
+    @Json(name = "to_field") val toField: String,
+)
+
+/** One drip sequence (mirrors DripSequenceOut). Stages come back as loosely-typed maps. */
+data class DripSequenceDto(
+    @Json(name = "sequence_id") val sequenceId: String,
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String = "",
+    @Json(name = "stages")
+    val stages: List<Map<String, @JvmSuppressWildcards Any?>> = emptyList(),
+    @Json(name = "created_by") val createdBy: String = "",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+/** The drip-sequence list envelope (mirrors DripSequenceListOut). */
+data class DripSequenceListDto(
+    @Json(name = "sequences") val sequences: List<DripSequenceDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+/** Create body for POST /drip-sequences (mirrors DripSequenceCreateIn). */
+data class DripSequenceCreateRequest(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String = "",
+    @Json(name = "stages") val stages: List<DripStageDto> = emptyList(),
+)
+
+/** Update body for PATCH /drip-sequences/{id} (mirrors DripSequenceUpdateIn). */
+data class DripSequenceUpdateRequest(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "stages") val stages: List<DripStageDto>? = null,
 )

--- a/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRulesApi.kt
+++ b/android/core-network/src/main/java/com/testlogon/android/core/network/workflow/WorkflowRulesApi.kt
@@ -1,18 +1,27 @@
 package com.testlogon.android.core.network.workflow
 
+import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.PATCH
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 /**
- * Retrofit interface for the SuiteCRM Workflow (WFL) admin endpoint surface — READ subset. Transport
- * only. Paths have NO leading slash (relative to the shared base URL). Session cookies / Authorization
- * Bearer / X-CSRF-Token are attached globally. These reads are admin-gated server-side (403 for members)
- * and the whole router 404s when CRM_WORKFLOW_ENABLED is off.
+ * Retrofit interface for the SuiteCRM Workflow (WFL) admin endpoint surface. Transport only. Paths have
+ * NO leading slash (relative to the shared base URL). Session cookies / Authorization Bearer /
+ * X-CSRF-Token are attached globally by the core-network interceptors, so mutating verbs need only the
+ * explicit JSON Content-Type header. Reads are admin-gated server-side (403 for members); mutations
+ * require admin/root + CSRF (403 otherwise). The whole router 404s when CRM_WORKFLOW_ENABLED is off, and
+ * the repository degrades on 404/403.
  *
- * Mirrors frontend/src/api/endpoints/crmWorkflow.ts listWorkflowRules / getWorkflowRule.
+ * Mirrors frontend/src/api/endpoints/crmWorkflow.ts (full rule CRUD + run history + drip-sequence CRUD).
  */
 interface WorkflowRulesApi {
+
+    // ----- Rule CRUD -----
 
     @GET("ui/admin/crm/workflow/rules")
     suspend fun listRules(
@@ -24,4 +33,60 @@ interface WorkflowRulesApi {
 
     @GET("ui/admin/crm/workflow/rules/{ruleId}")
     suspend fun getRule(@Path("ruleId") ruleId: String): WorkflowRuleDto
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/admin/crm/workflow/rules")
+    suspend fun createRule(@Body body: WorkflowRuleCreateRequest): WorkflowRuleDto
+
+    @Headers("Content-Type: application/json")
+    @PATCH("ui/admin/crm/workflow/rules/{ruleId}")
+    suspend fun updateRule(
+        @Path("ruleId") ruleId: String,
+        @Body body: WorkflowRuleUpdateRequest,
+    ): WorkflowRuleDto
+
+    @DELETE("ui/admin/crm/workflow/rules/{ruleId}")
+    suspend fun deleteRule(@Path("ruleId") ruleId: String)
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/admin/crm/workflow/rules/{ruleId}/enable")
+    suspend fun enableRule(@Path("ruleId") ruleId: String): WorkflowRuleDto
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/admin/crm/workflow/rules/{ruleId}/disable")
+    suspend fun disableRule(@Path("ruleId") ruleId: String): WorkflowRuleDto
+
+    // ----- Run history -----
+
+    @GET("ui/admin/crm/workflow/rules/{ruleId}/runs")
+    suspend fun listRuleRuns(
+        @Path("ruleId") ruleId: String,
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): WorkflowRunListDto
+
+    // ----- Drip sequences -----
+
+    @GET("ui/admin/crm/workflow/drip-sequences")
+    suspend fun listDripSequences(
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): DripSequenceListDto
+
+    @Headers("Content-Type: application/json")
+    @POST("ui/admin/crm/workflow/drip-sequences")
+    suspend fun createDripSequence(@Body body: DripSequenceCreateRequest): DripSequenceDto
+
+    @GET("ui/admin/crm/workflow/drip-sequences/{sequenceId}")
+    suspend fun getDripSequence(@Path("sequenceId") sequenceId: String): DripSequenceDto
+
+    @Headers("Content-Type: application/json")
+    @PATCH("ui/admin/crm/workflow/drip-sequences/{sequenceId}")
+    suspend fun updateDripSequence(
+        @Path("sequenceId") sequenceId: String,
+        @Body body: DripSequenceUpdateRequest,
+    ): DripSequenceDto
+
+    @DELETE("ui/admin/crm/workflow/drip-sequences/{sequenceId}")
+    suspend fun deleteDripSequence(@Path("sequenceId") sequenceId: String)
 }


### PR DESCRIPTION
## FE sweep SWP-145a - Android workflow-rules mutations + drip sequences

Adds create/update/delete mutations for workflow rules across the API, repository, and view-model layers, plus new drip-sequence and workflow-run screens.

- Workflow-rule CRUD mutations wired through `WorkflowRulesApi` / `WorkflowRulesRepository` / `WorkflowRulesViewModel`
- New `DripSequencesScreen` and `WorkflowRunsScreen` with navigation
- Extracted `WorkflowRuleDomain` models + pure `WorkflowRuleMath` helpers, covered by `WorkflowRuleMathTest`

All changes built and gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
