### PR TITLE
FE sweep SWP-141b - Android CRM events depth (invitees + registrations)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
@@ -1,7 +1,9 @@
 package com.testlogon.android.data.crm
 
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -66,6 +68,82 @@ interface CrmEventsApi {
 
     @GET("ui/crm/events/{eventId}/capacity")
     suspend fun getCapacity(@Path("eventId") eventId: String): CrmEventCapacityDto
+
+    // ── EVT-002: event update + invitee management ────────────────────────────
+
+    @PATCH("ui/crm/events/{eventId}")
+    suspend fun updateEvent(
+        @Path("eventId") eventId: String,
+        @Body body: CrmEventUpdateInDto,
+    ): CrmEventDto
+
+    @POST("ui/crm/events/{eventId}/invitees")
+    suspend fun addInvitee(
+        @Path("eventId") eventId: String,
+        @Body body: CrmInviteeAddInDto,
+    ): CrmInviteeDto
+
+    // 204 No Content on success → suspend Unit tolerates the empty body.
+    @DELETE("ui/crm/events/{eventId}/invitees/{inviteeSub}")
+    suspend fun removeInvitee(
+        @Path("eventId") eventId: String,
+        @Path("inviteeSub") inviteeSub: String,
+    )
+
+    @POST("ui/crm/events/{eventId}/invitees/bulk-import")
+    suspend fun bulkImportInvitees(
+        @Path("eventId") eventId: String,
+        @Body body: CrmInviteeBulkImportInDto,
+    ): CrmBulkImportDto
+
+    @POST("ui/crm/events/{eventId}/invitees/send-invitations")
+    suspend fun sendInvitations(
+        @Path("eventId") eventId: String,
+        @Body body: Map<String, String> = emptyMap(),
+    ): CrmSendInvitationsDto
+
+    @GET("ui/crm/events/{eventId}/invitees")
+    suspend fun listInvitees(
+        @Path("eventId") eventId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmInviteeListRespDto
+
+    // ── EVT-003: registration workflow ────────────────────────────────────────
+
+    @POST("ui/crm/events/{eventId}/registrations")
+    suspend fun registerForEvent(
+        @Path("eventId") eventId: String,
+        @Body body: Map<String, String> = emptyMap(),
+    ): CrmRegistrationDto
+
+    @POST("ui/crm/events/{eventId}/registrations/{registrantSub}/respond")
+    suspend fun respondToInvitation(
+        @Path("eventId") eventId: String,
+        @Path("registrantSub") registrantSub: String,
+        @Body body: CrmRespondInDto,
+    ): CrmRegistrationDto
+
+    @POST("ui/crm/events/{eventId}/registrations/{registrantSub}/check-in")
+    suspend fun checkInAttendee(
+        @Path("eventId") eventId: String,
+        @Path("registrantSub") registrantSub: String,
+        @Body body: Map<String, String> = emptyMap(),
+    ): CrmRegistrationDto
+
+    // 204 No Content on success → suspend Unit tolerates the empty body.
+    @DELETE("ui/crm/events/{eventId}/registrations/{registrantSub}")
+    suspend fun cancelRegistration(
+        @Path("eventId") eventId: String,
+        @Path("registrantSub") registrantSub: String,
+    )
+
+    @GET("ui/crm/events/{eventId}/registrations")
+    suspend fun listRegistrations(
+        @Path("eventId") eventId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmRegistrationListRespDto
 }
 
 // ─── Campaigns: prefix /ui/crm-marketing ─────────────────────────────────────

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
@@ -107,6 +107,79 @@ data class CrmEventCapacityDto(
     @Json(name = "available_spots") val availableSpots: Int? = null,
 )
 
+// EVT-002 — partial event update (PATCH). Only set fields are sent; nulls are omitted by Moshi.
+@JsonClass(generateAdapter = true)
+data class CrmEventUpdateInDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "calendar_event_id") val calendarEventId: String? = null,
+    @Json(name = "max_attendance") val maxAttendance: Int? = null,
+)
+
+// EVT-002 — invitee management.
+@JsonClass(generateAdapter = true)
+data class CrmInviteeAddInDto(
+    @Json(name = "invitee_sub") val inviteeSub: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmInviteeBulkImportInDto(
+    @Json(name = "user_subs") val userSubs: List<String>,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmInviteeDto(
+    @Json(name = "event_id") val eventId: String = "",
+    @Json(name = "invitee_sub") val inviteeSub: String = "",
+    @Json(name = "invite_status") val inviteStatus: String = "pending",
+    @Json(name = "invited_at") val invitedAt: Long = 0,
+    @Json(name = "responded_at") val respondedAt: Long? = null,
+    @Json(name = "display_name") val displayName: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmInviteeListRespDto(
+    @Json(name = "invitees") val invitees: List<CrmInviteeDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmBulkImportDto(
+    @Json(name = "added") val added: Int = 0,
+    @Json(name = "skipped") val skipped: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmSendInvitationsDto(
+    @Json(name = "sent") val sent: Int = 0,
+    @Json(name = "skipped") val skipped: Int = 0,
+    @Json(name = "failed") val failed: Int = 0,
+)
+
+// EVT-003 — registration / RSVP.
+@JsonClass(generateAdapter = true)
+data class CrmRespondInDto(
+    @Json(name = "new_status") val newStatus: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmRegistrationDto(
+    @Json(name = "event_id") val eventId: String = "",
+    @Json(name = "registrant_sub") val registrantSub: String = "",
+    @Json(name = "status") val status: String = "registered",
+    @Json(name = "registered_at") val registeredAt: Long = 0,
+    @Json(name = "responded_at") val respondedAt: Long? = null,
+    @Json(name = "checked_in_at") val checkedInAt: Long? = null,
+    @Json(name = "waitlist_position") val waitlistPosition: Int? = null,
+    @Json(name = "invited") val invited: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmRegistrationListRespDto(
+    @Json(name = "registrations") val registrations: List<CrmRegistrationDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
 // ──────────────────────────  CAMPAIGNS  ───────────────────────────
 
 @JsonClass(generateAdapter = true)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecMath.kt
@@ -79,6 +79,91 @@ object CrmPecMath {
             "$acceptedCount / $maxAttendance"
         }
 
+    // ── Event invitee / registration (EVT-002/003) ────────────────────────────
+    // Mirrors CrmInviteStatus / CrmRegistrationStatus in crmEvents.ts.
+
+    const val INVITE_PENDING = "pending"
+    const val INVITE_SENT = "sent"
+    const val INVITE_ACCEPTED = "accepted"
+    const val INVITE_DECLINED = "declined"
+
+    const val REG_REGISTERED = "registered"
+    const val REG_ACCEPTED = "accepted"
+    const val REG_DECLINED = "declined"
+    const val REG_WAITLISTED = "waitlisted"
+    const val REG_ATTENDED = "attended"
+
+    /** Human label for an invite status; unknown/blank keys are title-cased / em-dashed. */
+    fun inviteStatusLabel(status: String?): String = when (status) {
+        INVITE_PENDING -> "Pending"
+        INVITE_SENT -> "Invited"
+        INVITE_ACCEPTED -> "Accepted"
+        INVITE_DECLINED -> "Declined"
+        null -> EM_DASH
+        else -> titleCaseSnake(status)
+    }
+
+    /** Human label for a registration status; unknown/blank keys are title-cased / em-dashed. */
+    fun registrationStatusLabel(status: String?): String = when (status) {
+        REG_REGISTERED -> "Registered"
+        REG_ACCEPTED -> "Accepted"
+        REG_DECLINED -> "Declined"
+        REG_WAITLISTED -> "Waitlisted"
+        REG_ATTENDED -> "Attended"
+        null -> EM_DASH
+        else -> titleCaseSnake(status)
+    }
+
+    /** True when a "send invitations" action is meaningful (there is at least one un-sent invitee). */
+    fun canSendInvitations(pendingCount: Int): Boolean = pendingCount > 0
+
+    /** Count of invitees still awaiting a send (status pending). */
+    fun pendingInviteCount(statuses: List<String?>): Int =
+        statuses.count { it == INVITE_PENDING }
+
+    /**
+     * Whether a registrant may still RSVP (accept/decline). Once they have accepted, declined, or
+     * been checked in / marked attended, the RSVP action is closed. A waitlisted or freshly-registered
+     * row is still open.
+     */
+    fun canRespond(status: String?, checkedInAt: Long?): Boolean {
+        if (isCheckedIn(checkedInAt)) return false
+        return when (status) {
+            REG_ACCEPTED, REG_DECLINED, REG_ATTENDED -> false
+            else -> true
+        }
+    }
+
+    /** A registrant is checked-in when a positive check-in timestamp is present. */
+    fun isCheckedIn(checkedInAt: Long?): Boolean = checkedInAt != null && checkedInAt > 0
+
+    /**
+     * Whether an owner/admin may check a registrant in: only an accepted (or already-registered)
+     * attendee who has not yet been checked in. Declined / waitlisted attendees cannot be checked in.
+     */
+    fun canCheckIn(status: String?, checkedInAt: Long?): Boolean {
+        if (isCheckedIn(checkedInAt)) return false
+        return when (status) {
+            REG_ACCEPTED, REG_REGISTERED, REG_ATTENDED -> true
+            else -> false
+        }
+    }
+
+    /** Coarse RSVP state for surfacing chips / actions on a registration row. */
+    enum class RsvpState { PENDING, ACCEPTED, DECLINED, WAITLISTED, CHECKED_IN }
+
+    fun rsvpState(status: String?, checkedInAt: Long?): RsvpState = when {
+        isCheckedIn(checkedInAt) || status == REG_ATTENDED -> RsvpState.CHECKED_IN
+        status == REG_ACCEPTED -> RsvpState.ACCEPTED
+        status == REG_DECLINED -> RsvpState.DECLINED
+        status == REG_WAITLISTED -> RsvpState.WAITLISTED
+        else -> RsvpState.PENDING
+    }
+
+    /** "Waitlist #3" style label, or em-dash when not waitlisted / no position. */
+    fun waitlistLabel(position: Int?): String =
+        if (position == null || position <= 0) EM_DASH else "Waitlist #$position"
+
     // ── Campaign status / type ────────────────────────────────────────────────
 
     fun campaignStatusLabel(status: String?): String =

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
@@ -51,6 +51,39 @@ data class CrmEventCapacity(
     val availableSpots: Int?,
 )
 
+data class CrmInvitee(
+    val eventId: String,
+    val inviteeSub: String,
+    val inviteStatus: String,
+    val invitedAt: Long,
+    val respondedAt: Long?,
+    val displayName: String?,
+)
+
+data class CrmRegistration(
+    val eventId: String,
+    val registrantSub: String,
+    val status: String,
+    val registeredAt: Long,
+    val respondedAt: Long?,
+    val checkedInAt: Long?,
+    val waitlistPosition: Int?,
+    val invited: Boolean?,
+)
+
+/** Roll-up of a send-invitations run. */
+data class CrmSendInvitationsResult(
+    val sent: Int,
+    val skipped: Int,
+    val failed: Int,
+)
+
+/** Roll-up of a bulk-import run. */
+data class CrmBulkImportResult(
+    val added: Int,
+    val skipped: Int,
+)
+
 // ─── Campaigns ───────────────────────────────────────────────────────────────
 
 data class CrmCampaign(
@@ -116,6 +149,37 @@ fun CrmEventCapacityDto.toDomain(): CrmEventCapacity = CrmEventCapacity(
     acceptedCount = acceptedCount,
     waitlistedCount = waitlistedCount,
     availableSpots = availableSpots,
+)
+
+fun CrmInviteeDto.toDomain(): CrmInvitee = CrmInvitee(
+    eventId = eventId,
+    inviteeSub = inviteeSub,
+    inviteStatus = inviteStatus,
+    invitedAt = invitedAt,
+    respondedAt = respondedAt,
+    displayName = displayName,
+)
+
+fun CrmRegistrationDto.toDomain(): CrmRegistration = CrmRegistration(
+    eventId = eventId,
+    registrantSub = registrantSub,
+    status = status,
+    registeredAt = registeredAt,
+    respondedAt = respondedAt,
+    checkedInAt = checkedInAt,
+    waitlistPosition = waitlistPosition,
+    invited = invited,
+)
+
+fun CrmSendInvitationsDto.toDomain(): CrmSendInvitationsResult = CrmSendInvitationsResult(
+    sent = sent,
+    skipped = skipped,
+    failed = failed,
+)
+
+fun CrmBulkImportDto.toDomain(): CrmBulkImportResult = CrmBulkImportResult(
+    added = added,
+    skipped = skipped,
 )
 
 fun CrmCampaignDto.toDomain(): CrmCampaign = CrmCampaign(

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
@@ -31,6 +31,18 @@ data class CrmEventsPage(
     val moduleDisabled: Boolean = false,
 )
 
+data class CrmInviteesPage(
+    val invitees: List<CrmInvitee>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
+data class CrmRegistrationsPage(
+    val registrations: List<CrmRegistration>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
 data class CrmCampaignsPage(
     val campaigns: List<CrmCampaign>,
     val cursor: String?,
@@ -97,6 +109,21 @@ interface CrmEventsRepository {
     suspend fun get(eventId: String): ApiResult<CrmEvent>
     suspend fun capacity(eventId: String): ApiResult<CrmEventCapacity?>
     suspend fun create(body: CrmEventCreateInDto): ApiResult<CrmEvent>
+
+    // EVT-002 — event update + invitee management.
+    suspend fun update(eventId: String, body: CrmEventUpdateInDto): ApiResult<CrmEvent>
+    suspend fun addInvitee(eventId: String, inviteeSub: String): ApiResult<CrmInvitee>
+    suspend fun removeInvitee(eventId: String, inviteeSub: String): ApiResult<Unit>
+    suspend fun bulkImportInvitees(eventId: String, userSubs: List<String>): ApiResult<CrmBulkImportResult>
+    suspend fun sendInvitations(eventId: String): ApiResult<CrmSendInvitationsResult>
+    suspend fun listInvitees(eventId: String): ApiResult<CrmInviteesPage>
+
+    // EVT-003 — registration / RSVP / check-in.
+    suspend fun register(eventId: String): ApiResult<CrmRegistration>
+    suspend fun respond(eventId: String, registrantSub: String, newStatus: String): ApiResult<CrmRegistration>
+    suspend fun checkIn(eventId: String, registrantSub: String): ApiResult<CrmRegistration>
+    suspend fun cancelRegistration(eventId: String, registrantSub: String): ApiResult<Unit>
+    suspend fun listRegistrations(eventId: String): ApiResult<CrmRegistrationsPage>
 }
 
 @Singleton
@@ -133,6 +160,73 @@ class CrmEventsRepositoryImpl @Inject constructor(
 
     override suspend fun create(body: CrmEventCreateInDto): ApiResult<CrmEvent> = withContext(io) {
         call { api.createEvent(body).toDomain() }
+    }
+
+    override suspend fun update(eventId: String, body: CrmEventUpdateInDto): ApiResult<CrmEvent> = withContext(io) {
+        call { api.updateEvent(eventId, body).toDomain() }
+    }
+
+    override suspend fun addInvitee(eventId: String, inviteeSub: String): ApiResult<CrmInvitee> = withContext(io) {
+        call { api.addInvitee(eventId, CrmInviteeAddInDto(inviteeSub = inviteeSub)).toDomain() }
+    }
+
+    override suspend fun removeInvitee(eventId: String, inviteeSub: String): ApiResult<Unit> = withContext(io) {
+        call { api.removeInvitee(eventId, inviteeSub) }
+    }
+
+    override suspend fun bulkImportInvitees(
+        eventId: String,
+        userSubs: List<String>,
+    ): ApiResult<CrmBulkImportResult> = withContext(io) {
+        call { api.bulkImportInvitees(eventId, CrmInviteeBulkImportInDto(userSubs = userSubs)).toDomain() }
+    }
+
+    override suspend fun sendInvitations(eventId: String): ApiResult<CrmSendInvitationsResult> = withContext(io) {
+        call { api.sendInvitations(eventId).toDomain() }
+    }
+
+    override suspend fun listInvitees(eventId: String): ApiResult<CrmInviteesPage> = withContext(io) {
+        when (val r = call { api.listInvitees(eventId) }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmInviteesPage(r.data.invitees.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (r.error.status == 404) ApiResult.Success(CrmInviteesPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun register(eventId: String): ApiResult<CrmRegistration> = withContext(io) {
+        call { api.registerForEvent(eventId).toDomain() }
+    }
+
+    override suspend fun respond(
+        eventId: String,
+        registrantSub: String,
+        newStatus: String,
+    ): ApiResult<CrmRegistration> = withContext(io) {
+        call { api.respondToInvitation(eventId, registrantSub, CrmRespondInDto(newStatus = newStatus)).toDomain() }
+    }
+
+    override suspend fun checkIn(eventId: String, registrantSub: String): ApiResult<CrmRegistration> = withContext(io) {
+        call { api.checkInAttendee(eventId, registrantSub).toDomain() }
+    }
+
+    override suspend fun cancelRegistration(eventId: String, registrantSub: String): ApiResult<Unit> = withContext(io) {
+        call { api.cancelRegistration(eventId, registrantSub) }
+    }
+
+    override suspend fun listRegistrations(eventId: String): ApiResult<CrmRegistrationsPage> = withContext(io) {
+        when (val r = call { api.listRegistrations(eventId) }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmRegistrationsPage(r.data.registrations.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (r.error.status == 404) ApiResult.Success(CrmRegistrationsPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
     }
 
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventDetailScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventDetailScreen.kt
@@ -1,0 +1,387 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CrmInvitee
+import com.testlogon.android.data.crm.CrmPecMath
+import com.testlogon.android.data.crm.CrmRegistration
+
+object CrmEventDetailTestTags {
+    const val SCREEN = "crm_event_detail_screen"
+    const val LOADING = "crm_event_detail_loading"
+    const val ERROR = "crm_event_detail_error"
+    const val ADD_INVITEE = "crm_event_add_invitee"
+    const val SEND_INVITES = "crm_event_send_invites"
+    const val REGISTER = "crm_event_register"
+}
+
+@Composable
+fun CrmEventDetailRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmEventDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmEventDetailScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onUpdate = viewModel::updateEvent,
+        onAddInvitee = viewModel::addInvitee,
+        onRemoveInvitee = viewModel::removeInvitee,
+        onBulkImport = viewModel::bulkImport,
+        onSendInvitations = viewModel::sendInvitations,
+        onRegister = viewModel::register,
+        onRespond = viewModel::respond,
+        onCheckIn = viewModel::checkIn,
+        onCancelRegistration = viewModel::cancelRegistration,
+        onClearActionFeedback = viewModel::clearActionFeedback,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmEventDetailScreen(
+    state: CrmEventDetailUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onUpdate: (String?, String?, Int?) -> Unit,
+    onAddInvitee: (String) -> Unit,
+    onRemoveInvitee: (String) -> Unit,
+    onBulkImport: (List<String>) -> Unit,
+    onSendInvitations: () -> Unit,
+    onRegister: () -> Unit,
+    onRespond: (String, String) -> Unit,
+    onCheckIn: (String) -> Unit,
+    onCancelRegistration: (String) -> Unit,
+    onClearActionFeedback: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showEdit by remember { mutableStateOf(false) }
+    var showAddInvitee by remember { mutableStateOf(false) }
+    var showBulkImport by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmEventDetailTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(state.event?.name?.ifBlank { "Event" } ?: "Event") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmEventDetailUiState.Phase.Loading -> LoadingState(
+                modifier = Modifier.padding(padding).testTag(CrmEventDetailTestTags.LOADING),
+            )
+            CrmEventDetailUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load this event.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding).testTag(CrmEventDetailTestTags.ERROR),
+            )
+            CrmEventDetailUiState.Phase.Content -> {
+                val event = state.event
+                Column(
+                    modifier = Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.actionMessage != null) InfoBanner(state.actionMessage)
+                    if (state.actionError != null) {
+                        Text(state.actionError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                    }
+
+                    if (event != null) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                            val cap = state.capacity
+                            AssistChip(
+                                onClick = {},
+                                label = {
+                                    Text(CrmPecMath.capacityLabel(cap?.maxAttendance ?: event.maxAttendance, cap?.acceptedCount ?: 0))
+                                },
+                            )
+                            if ((cap?.waitlistedCount ?: 0) > 0) {
+                                AssistChip(onClick = {}, label = { Text("${cap?.waitlistedCount} waitlisted") })
+                            }
+                        }
+                        if (event.description.isNotBlank()) LabeledValue("Description", event.description)
+                        LabeledValue("Created", CrmPecMath.formatDate(event.createdAt))
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedButton(onClick = { showEdit = true }) { Text("Edit") }
+                            FilledTonalButton(
+                                onClick = onRegister,
+                                enabled = !state.actionInProgress,
+                                modifier = Modifier.testTag(CrmEventDetailTestTags.REGISTER),
+                            ) { Text("Register") }
+                        }
+                    }
+
+                    // ── Invitees ──────────────────────────────────────────────
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text("Invitees (${state.invitees.size})", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            TextButton(onClick = { showBulkImport = true }, enabled = !state.actionInProgress) { Text("Import") }
+                            TextButton(
+                                onClick = { showAddInvitee = true },
+                                enabled = !state.actionInProgress,
+                                modifier = Modifier.testTag(CrmEventDetailTestTags.ADD_INVITEE),
+                            ) { Text("Add") }
+                        }
+                    }
+                    if (state.canSendInvitations) {
+                        FilledTonalButton(
+                            onClick = onSendInvitations,
+                            enabled = !state.actionInProgress,
+                            modifier = Modifier.fillMaxWidth().testTag(CrmEventDetailTestTags.SEND_INVITES),
+                        ) { Text("Send invitations (${state.pendingInviteCount} pending)") }
+                    }
+                    if (state.invitees.isEmpty()) {
+                        Text("No invitees yet.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    } else {
+                        state.invitees.forEach { invitee ->
+                            InviteeRow(invitee, enabled = !state.actionInProgress, onRemove = { onRemoveInvitee(invitee.inviteeSub) })
+                        }
+                    }
+
+                    // ── Registrations / RSVP / check-in ───────────────────────
+                    Text("Registrations (${state.registrations.size})", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    if (state.registrations.isEmpty()) {
+                        Text("No registrations yet.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    } else {
+                        state.registrations.forEach { reg ->
+                            RegistrationRow(
+                                reg = reg,
+                                enabled = !state.actionInProgress,
+                                onAccept = { onRespond(reg.registrantSub, CrmPecMath.REG_ACCEPTED) },
+                                onDecline = { onRespond(reg.registrantSub, CrmPecMath.REG_DECLINED) },
+                                onCheckIn = { onCheckIn(reg.registrantSub) },
+                                onCancel = { onCancelRegistration(reg.registrantSub) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showEdit && state.event != null) {
+        EditEventSheet(
+            initialName = state.event.name,
+            initialDescription = state.event.description,
+            initialMax = state.event.maxAttendance,
+            submitting = state.actionInProgress,
+            onDismiss = { showEdit = false; onClearActionFeedback() },
+            onSubmit = { name, desc, maxAtt ->
+                onUpdate(name, desc, maxAtt)
+                showEdit = false
+            },
+        )
+    }
+
+    if (showAddInvitee) {
+        SingleFieldSheet(
+            title = "Add invitee",
+            label = "User id (sub)",
+            submitting = state.actionInProgress,
+            onDismiss = { showAddInvitee = false; onClearActionFeedback() },
+            onSubmit = { value -> onAddInvitee(value); showAddInvitee = false },
+        )
+    }
+
+    if (showBulkImport) {
+        SingleFieldSheet(
+            title = "Bulk import invitees",
+            label = "User ids (comma or newline separated)",
+            singleLine = false,
+            submitting = state.actionInProgress,
+            onDismiss = { showBulkImport = false; onClearActionFeedback() },
+            onSubmit = { value ->
+                onBulkImport(value.split(',', '\n', ' '))
+                showBulkImport = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun InviteeRow(invitee: CrmInvitee, enabled: Boolean, onRemove: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    (invitee.displayName ?: invitee.inviteeSub).ifBlank { "(unknown)" },
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    CrmPecMath.inviteStatusLabel(invitee.inviteStatus),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = onRemove, enabled = enabled) {
+                Icon(Icons.Filled.Close, contentDescription = "Remove invitee")
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegistrationRow(
+    reg: CrmRegistration,
+    enabled: Boolean,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onCheckIn: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                Text(reg.registrantSub.ifBlank { "(unknown)" }, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                AssistChip(onClick = {}, label = { Text(CrmPecMath.registrationStatusLabel(reg.status)) })
+            }
+            if (reg.waitlistPosition != null && reg.waitlistPosition > 0) {
+                Text(CrmPecMath.waitlistLabel(reg.waitlistPosition), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (CrmPecMath.canRespond(reg.status, reg.checkedInAt)) {
+                    TextButton(onClick = onAccept, enabled = enabled) { Text("Accept") }
+                    TextButton(onClick = onDecline, enabled = enabled) { Text("Decline") }
+                }
+                if (CrmPecMath.canCheckIn(reg.status, reg.checkedInAt)) {
+                    TextButton(onClick = onCheckIn, enabled = enabled) { Text("Check in") }
+                }
+                if (CrmPecMath.isCheckedIn(reg.checkedInAt)) {
+                    Text("Checked in", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                }
+                TextButton(onClick = onCancel, enabled = enabled) { Text("Cancel") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditEventSheet(
+    initialName: String,
+    initialDescription: String,
+    initialMax: Int?,
+    submitting: Boolean,
+    onDismiss: () -> Unit,
+    onSubmit: (name: String?, description: String?, maxAttendance: Int?) -> Unit,
+) {
+    var name by remember { mutableStateOf(initialName) }
+    var description by remember { mutableStateOf(initialDescription) }
+    var maxAtt by remember { mutableStateOf(initialMax?.toString() ?: "") }
+
+    AlertDialog(
+        onDismissRequest = { if (!submitting) onDismiss() },
+        title = { Text("Edit event") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(name, { name = it }, label = { Text("Name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(description, { description = it }, label = { Text("Description") }, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(
+                    maxAtt,
+                    { input -> maxAtt = input.filter { it.isDigit() } },
+                    label = { Text("Max attendance (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !submitting, onClick = { onSubmit(name, description, maxAtt.toIntOrNull()) }) {
+                if (submitting) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Save")
+            }
+        },
+        dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun SingleFieldSheet(
+    title: String,
+    label: String,
+    submitting: Boolean,
+    singleLine: Boolean = true,
+    onDismiss: () -> Unit,
+    onSubmit: (String) -> Unit,
+) {
+    var value by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = { if (!submitting) onDismiss() },
+        title = { Text(title) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(value, { value = it }, label = { Text(label) }, singleLine = singleLine, modifier = Modifier.fillMaxWidth())
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !submitting, onClick = { onSubmit(value) }) {
+                if (submitting) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Save")
+            }
+        },
+        dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventDetailViewModel.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventDetailViewModel.kt
@@ -1,0 +1,193 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmEvent
+import com.testlogon.android.data.crm.CrmEventCapacity
+import com.testlogon.android.data.crm.CrmEventUpdateInDto
+import com.testlogon.android.data.crm.CrmEventsRepository
+import com.testlogon.android.data.crm.CrmInvitee
+import com.testlogon.android.data.crm.CrmPecMath
+import com.testlogon.android.data.crm.CrmRegistration
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * CRM-AND-PEC / EVT-002-004 — event detail: metadata + capacity + invitee management + registration /
+ * RSVP / check-in. Mirrors frontend/src/api/endpoints/crmEvents.ts. Every sub-resource load degrades on
+ * 404 (module disabled) or failure to an empty section rather than failing the whole screen.
+ */
+data class CrmEventDetailUiState(
+    val phase: Phase = Phase.Loading,
+    val event: CrmEvent? = null,
+    val capacity: CrmEventCapacity? = null,
+    val invitees: List<CrmInvitee> = emptyList(),
+    val registrations: List<CrmRegistration> = emptyList(),
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    // transient action feedback
+    val actionInProgress: Boolean = false,
+    val actionError: String? = null,
+    val actionMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    val pendingInviteCount: Int
+        get() = CrmPecMath.pendingInviteCount(invitees.map { it.inviteStatus })
+
+    val canSendInvitations: Boolean
+        get() = CrmPecMath.canSendInvitations(pendingInviteCount)
+}
+
+@HiltViewModel
+class CrmEventDetailViewModel @Inject constructor(
+    private val repository: CrmEventsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val eventId: String = checkNotNull(savedStateHandle[ARG_EVENT_ID]) {
+        "CrmEventDetailViewModel requires a $ARG_EVENT_ID nav arg"
+    }
+
+    private val _uiState = MutableStateFlow(CrmEventDetailUiState())
+    val uiState: StateFlow<CrmEventDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update {
+            it.copy(phase = if (it.event == null) CrmEventDetailUiState.Phase.Loading else it.phase)
+        }
+        viewModelScope.launch {
+            when (val r = repository.get(eventId)) {
+                is ApiResult.Success -> {
+                    val capacity = (repository.capacity(eventId) as? ApiResult.Success)?.data
+                    val invitees = (repository.listInvitees(eventId) as? ApiResult.Success)?.data?.invitees ?: emptyList()
+                    val registrations =
+                        (repository.listRegistrations(eventId) as? ApiResult.Success)?.data?.registrations ?: emptyList()
+                    _uiState.update {
+                        it.copy(
+                            phase = CrmEventDetailUiState.Phase.Content,
+                            event = r.data,
+                            capacity = capacity,
+                            invitees = invitees,
+                            registrations = registrations,
+                            isOffline = false,
+                            errorMessage = null,
+                        )
+                    }
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.event != null) CrmEventDetailUiState.Phase.Content else CrmEventDetailUiState.Phase.Error,
+                        isOffline = false,
+                        errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.event != null) CrmEventDetailUiState.Phase.Content else CrmEventDetailUiState.Phase.Error,
+                        isOffline = true,
+                        errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    // ── EVT-002: event update ─────────────────────────────────────────────────
+
+    fun updateEvent(name: String?, description: String?, maxAttendance: Int?) {
+        runAction("Event updated.") {
+            repository.update(
+                eventId,
+                CrmEventUpdateInDto(
+                    name = name?.trim()?.ifBlank { null },
+                    description = description?.trim(),
+                    maxAttendance = maxAttendance,
+                ),
+            )
+        }
+    }
+
+    // ── EVT-002: invitee management ───────────────────────────────────────────
+
+    fun addInvitee(inviteeSub: String) {
+        if (inviteeSub.isBlank()) {
+            _uiState.update { it.copy(actionError = "A user id is required.") }
+            return
+        }
+        runAction("Invitee added.") { repository.addInvitee(eventId, inviteeSub.trim()) }
+    }
+
+    fun removeInvitee(inviteeSub: String) {
+        runAction("Invitee removed.") { repository.removeInvitee(eventId, inviteeSub) }
+    }
+
+    fun bulkImport(userSubs: List<String>) {
+        val cleaned = userSubs.map { it.trim() }.filter { it.isNotBlank() }.distinct()
+        if (cleaned.isEmpty()) {
+            _uiState.update { it.copy(actionError = "Enter at least one user id.") }
+            return
+        }
+        runAction("Invitees imported.") { repository.bulkImportInvitees(eventId, cleaned) }
+    }
+
+    fun sendInvitations() {
+        runAction("Invitations sent.") { repository.sendInvitations(eventId) }
+    }
+
+    // ── EVT-003: registration / RSVP / check-in ───────────────────────────────
+
+    fun register() {
+        runAction("Registered.") { repository.register(eventId) }
+    }
+
+    fun respond(registrantSub: String, newStatus: String) {
+        runAction("RSVP updated.") { repository.respond(eventId, registrantSub, newStatus) }
+    }
+
+    fun checkIn(registrantSub: String) {
+        runAction("Checked in.") { repository.checkIn(eventId, registrantSub) }
+    }
+
+    fun cancelRegistration(registrantSub: String) {
+        runAction("Registration cancelled.") { repository.cancelRegistration(eventId, registrantSub) }
+    }
+
+    fun clearActionFeedback() = _uiState.update { it.copy(actionError = null, actionMessage = null) }
+
+    /** Runs a mutating action, then re-loads on success so every derived section refreshes. */
+    private fun <T> runAction(successMessage: String, block: suspend () -> ApiResult<T>) {
+        _uiState.update { it.copy(actionInProgress = true, actionError = null, actionMessage = null) }
+        viewModelScope.launch {
+            when (val r = block()) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(actionInProgress = false, actionMessage = successMessage) }
+                    load()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(actionInProgress = false, actionError = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(actionInProgress = false, actionError = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_EVENT_ID: String = "eventId"
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventsScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmEventsScreen.kt
@@ -60,6 +60,7 @@ object CrmEventsTestTags {
 
 @Composable
 fun CrmEventsRoute(
+    onEventClick: (String) -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CrmEventsViewModel = hiltViewModel(),
@@ -67,6 +68,7 @@ fun CrmEventsRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     CrmEventsScreen(
         state = state,
+        onEventClick = onEventClick,
         onBack = onBack,
         onRefresh = viewModel::onRefresh,
         onRetry = viewModel::onRetry,
@@ -79,6 +81,7 @@ fun CrmEventsRoute(
 @Composable
 fun CrmEventsScreen(
     state: CrmEventsUiState,
+    onEventClick: (String) -> Unit,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
@@ -136,7 +139,9 @@ fun CrmEventsScreen(
                             contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            items(state.events, key = { it.eventId }) { event -> EventRow(event) }
+                            items(state.events, key = { it.eventId }) { event ->
+                                EventRow(event, onClick = { onEventClick(event.eventId) })
+                            }
                         }
                     }
                 }
@@ -160,8 +165,8 @@ fun CrmEventsScreen(
 }
 
 @Composable
-private fun EventRow(event: CrmEvent) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+private fun EventRow(event: CrmEvent, onClick: () -> Unit) {
+    Card(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
@@ -14,6 +14,8 @@ import com.testlogon.android.feature.crm.CrmProjectsRoute
 import com.testlogon.android.feature.crm.CrmProjectDetailRoute
 import com.testlogon.android.feature.crm.CrmProjectDetailViewModel
 import com.testlogon.android.feature.crm.CrmEventsRoute
+import com.testlogon.android.feature.crm.CrmEventDetailRoute
+import com.testlogon.android.feature.crm.CrmEventDetailViewModel
 import com.testlogon.android.feature.crm.CrmCampaignsRoute
 import com.testlogon.android.feature.crm.CrmCampaignDetailRoute
 import com.testlogon.android.feature.crm.CrmCampaignDetailViewModel
@@ -52,6 +54,14 @@ data object CrmProjectDetailDest {
 /** CRM-AND-PEC — the CRM events list route (Growth hub). */
 data object CrmEventsDest {
     const val ROUTE = "crm/events"
+}
+
+/** CRM-AND-PEC — the CRM event detail route; the arg is the STRING event id (path param). */
+data object CrmEventDetailDest {
+    const val ARG_EVENT_ID = CrmEventDetailViewModel.ARG_EVENT_ID
+    const val ROUTE = "crm/events/{$ARG_EVENT_ID}"
+
+    fun build(eventId: String): String = "crm/events/${Uri.encode(eventId)}"
 }
 
 /** CRM-AND-PEC — the CRM marketing campaigns list route (Growth hub). */
@@ -106,7 +116,20 @@ fun NavGraphBuilder.crmDestinations(navController: NavHostController) {
         CrmProjectDetailRoute(onBack = { navController.popBackStack() })
     }
     composable(CrmEventsDest.ROUTE) {
-        CrmEventsRoute(onBack = { navController.popBackStack() })
+        CrmEventsRoute(
+            onEventClick = { id ->
+                navController.navigate(CrmEventDetailDest.build(id)) { launchSingleTop = true }
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable(
+        route = CrmEventDetailDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmEventDetailDest.ARG_EVENT_ID) { type = NavType.StringType },
+        ),
+    ) {
+        CrmEventDetailRoute(onBack = { navController.popBackStack() })
     }
     composable(CrmCampaignsDest.ROUTE) {
         CrmCampaignsRoute(

--- a/android/app/src/test/java/com/testlogon/android/data/crm/CrmPecMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/crm/CrmPecMathTest.kt
@@ -143,4 +143,102 @@ class CrmPecMathTest {
         assertEquals("2021-01-01 → ${CrmPecMath.EM_DASH}", CrmPecMath.dateRange(1_609_459_200L, null))
         assertEquals("2021-01-01 → 2021-01-01", CrmPecMath.dateRange(1_609_459_200L, 1_609_459_200L))
     }
+
+    // ── Event invitee / registration (EVT-002/003) ────────────────────────────
+
+    @Test
+    fun inviteStatusLabel_knownAndDegrade() {
+        assertEquals("Pending", CrmPecMath.inviteStatusLabel("pending"))
+        assertEquals("Invited", CrmPecMath.inviteStatusLabel("sent"))
+        assertEquals("Accepted", CrmPecMath.inviteStatusLabel("accepted"))
+        assertEquals("Declined", CrmPecMath.inviteStatusLabel("declined"))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.inviteStatusLabel(null))
+        assertEquals("Bounced Back", CrmPecMath.inviteStatusLabel("bounced_back"))
+    }
+
+    @Test
+    fun registrationStatusLabel_knownAndDegrade() {
+        assertEquals("Registered", CrmPecMath.registrationStatusLabel("registered"))
+        assertEquals("Accepted", CrmPecMath.registrationStatusLabel("accepted"))
+        assertEquals("Declined", CrmPecMath.registrationStatusLabel("declined"))
+        assertEquals("Waitlisted", CrmPecMath.registrationStatusLabel("waitlisted"))
+        assertEquals("Attended", CrmPecMath.registrationStatusLabel("attended"))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.registrationStatusLabel(null))
+        assertEquals("No Show", CrmPecMath.registrationStatusLabel("no_show"))
+    }
+
+    @Test
+    fun pendingInviteCount_countsOnlyPending() {
+        val statuses = listOf("pending", "sent", "pending", null, "accepted")
+        assertEquals(2, CrmPecMath.pendingInviteCount(statuses))
+        assertEquals(0, CrmPecMath.pendingInviteCount(emptyList()))
+    }
+
+    @Test
+    fun canSendInvitations_gatedByPending() {
+        assertTrue(CrmPecMath.canSendInvitations(1))
+        assertTrue(CrmPecMath.canSendInvitations(5))
+        assertFalse(CrmPecMath.canSendInvitations(0))
+        assertFalse(CrmPecMath.canSendInvitations(-3))
+    }
+
+    @Test
+    fun isCheckedIn_positiveTimestampOnly() {
+        assertTrue(CrmPecMath.isCheckedIn(1_609_459_200L))
+        assertFalse(CrmPecMath.isCheckedIn(null))
+        assertFalse(CrmPecMath.isCheckedIn(0L))
+        assertFalse(CrmPecMath.isCheckedIn(-1L))
+    }
+
+    @Test
+    fun canRespond_openWhilePendingOrWaitlisted() {
+        assertTrue(CrmPecMath.canRespond("registered", null))
+        assertTrue(CrmPecMath.canRespond("waitlisted", null))
+        assertTrue(CrmPecMath.canRespond(null, null))
+    }
+
+    @Test
+    fun canRespond_closedAfterDecisionOrCheckIn() {
+        assertFalse(CrmPecMath.canRespond("accepted", null))
+        assertFalse(CrmPecMath.canRespond("declined", null))
+        assertFalse(CrmPecMath.canRespond("attended", null))
+        // checked-in closes RSVP even if status still says registered
+        assertFalse(CrmPecMath.canRespond("registered", 1_609_459_200L))
+    }
+
+    @Test
+    fun canCheckIn_onlyAcceptedOrRegisteredNotYetIn() {
+        assertTrue(CrmPecMath.canCheckIn("accepted", null))
+        assertTrue(CrmPecMath.canCheckIn("registered", null))
+        assertFalse(CrmPecMath.canCheckIn("declined", null))
+        assertFalse(CrmPecMath.canCheckIn("waitlisted", null))
+        // already checked-in cannot be checked in again
+        assertFalse(CrmPecMath.canCheckIn("accepted", 1_609_459_200L))
+    }
+
+    @Test
+    fun rsvpState_derivesCoarseState() {
+        assertEquals(CrmPecMath.RsvpState.CHECKED_IN, CrmPecMath.rsvpState("accepted", 1_609_459_200L))
+        assertEquals(CrmPecMath.RsvpState.CHECKED_IN, CrmPecMath.rsvpState("attended", null))
+        assertEquals(CrmPecMath.RsvpState.ACCEPTED, CrmPecMath.rsvpState("accepted", null))
+        assertEquals(CrmPecMath.RsvpState.DECLINED, CrmPecMath.rsvpState("declined", null))
+        assertEquals(CrmPecMath.RsvpState.WAITLISTED, CrmPecMath.rsvpState("waitlisted", null))
+        assertEquals(CrmPecMath.RsvpState.PENDING, CrmPecMath.rsvpState("registered", null))
+        assertEquals(CrmPecMath.RsvpState.PENDING, CrmPecMath.rsvpState(null, null))
+    }
+
+    @Test
+    fun waitlistLabel_formatsAndDegrades() {
+        assertEquals("Waitlist #3", CrmPecMath.waitlistLabel(3))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.waitlistLabel(null))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.waitlistLabel(0))
+        assertEquals(CrmPecMath.EM_DASH, CrmPecMath.waitlistLabel(-2))
+    }
+
+    @Test
+    fun capacityLabel_cappedAndUncapped() {
+        assertEquals("3 / 10", CrmPecMath.capacityLabel(10, 3))
+        assertEquals("5 going", CrmPecMath.capacityLabel(null, 5))
+        assertEquals("0 going", CrmPecMath.capacityLabel(0, 0))
+    }
 }


### PR DESCRIPTION
## FE sweep SWP-141b - Android CRM events depth (invitees + registrations)

Adds depth to the Android CRM events surface:

- New event detail screen (`CrmEventDetailScreen`) plus its view model, surfacing per-event invitees and registrations.
- CRM navigation wired to route from the events list into the detail screen.
- PEC API / DTOs / models / repository extended to carry invitee and registration data.
- Math helpers + unit tests updated to cover the new registration/invitee aggregates.

All changes are built and gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
