### PR TITLE
FE sweep SWP-140b - Android CRM opportunities depth (forecast/quota/reports/contacts)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmDtos.kt
@@ -289,3 +289,104 @@ data class ProspectUpdateInDto(
     @Json(name = "phone") val phone: String? = null,
     @Json(name = "company") val company: String? = null,
 )
+
+
+// ─────────  OPPORTUNITIES: forecast / quota / reports / contact-roles (CRM-AND-OPP)  ─────────
+// Mirrors frontend/src/api/endpoints/opportunities.ts + the Pydantic models in app/models.py.
+
+@JsonClass(generateAdapter = true)
+data class OppContactRoleOutDto(
+    @Json(name = "opp_id") val oppId: String = "",
+    @Json(name = "contact_ref") val contactRef: String = "",
+    @Json(name = "contact_role") val contactRole: String = "",
+    @Json(name = "owner_sub") val ownerSub: String = "",
+    @Json(name = "created_at") val createdAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class OppContactRoleInDto(
+    @Json(name = "contact_ref") val contactRef: String,
+    @Json(name = "contact_role") val contactRole: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class PipelineStageMetricDto(
+    @Json(name = "stage") val stage: String = "",
+    @Json(name = "label") val label: String = "",
+    @Json(name = "count") val count: Int = 0,
+    @Json(name = "total_amount_cents") val totalAmountCents: Long = 0,
+    @Json(name = "weighted_amount_cents") val weightedAmountCents: Long = 0,
+    @Json(name = "avg_close_date") val avgCloseDate: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class PipelineReportOutDto(
+    @Json(name = "stages") val stages: List<PipelineStageMetricDto> = emptyList(),
+    @Json(name = "total_amount_cents") val totalAmountCents: Long = 0,
+    @Json(name = "total_weighted_cents") val totalWeightedCents: Long = 0,
+    @Json(name = "generated_at") val generatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class ForecastWorksheetInDto(
+    @Json(name = "committed_cents") val committedCents: Long,
+    @Json(name = "best_case_cents") val bestCaseCents: Long,
+    @Json(name = "pipeline_cents") val pipelineCents: Long,
+    @Json(name = "notes") val notes: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ForecastWorksheetOutDto(
+    @Json(name = "user_sub") val userSub: String = "",
+    @Json(name = "period_key") val periodKey: String = "",
+    @Json(name = "committed_cents") val committedCents: Long = 0,
+    @Json(name = "best_case_cents") val bestCaseCents: Long = 0,
+    @Json(name = "pipeline_cents") val pipelineCents: Long = 0,
+    @Json(name = "closed_cents") val closedCents: Long = 0,
+    @Json(name = "quota_cents") val quotaCents: Long = 0,
+    @Json(name = "attainment_pct") val attainmentPct: Int = 0,
+    @Json(name = "notes") val notes: String? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class SalesQuotaInDto(
+    @Json(name = "user_sub") val userSub: String,
+    @Json(name = "period_type") val periodType: String,
+    @Json(name = "period_key") val periodKey: String,
+    @Json(name = "target_amount_cents") val targetAmountCents: Long,
+)
+
+@JsonClass(generateAdapter = true)
+data class SalesQuotaOutDto(
+    @Json(name = "user_sub") val userSub: String = "",
+    @Json(name = "period_type") val periodType: String = "",
+    @Json(name = "period_key") val periodKey: String = "",
+    @Json(name = "target_amount_cents") val targetAmountCents: Long = 0,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+    @Json(name = "set_by_sub") val setBySub: String = "",
+)
+
+@JsonClass(generateAdapter = true)
+data class SalesQuotaListOutDto(
+    @Json(name = "items") val items: List<SalesQuotaOutDto> = emptyList(),
+    @Json(name = "next_cursor") val nextCursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StageConfigItemInDto(
+    @Json(name = "stage_key") val stageKey: String,
+    @Json(name = "label") val label: String,
+    @Json(name = "probability_default") val probabilityDefault: Int = 0,
+    @Json(name = "order") val order: Int = 0,
+    @Json(name = "is_won") val isWon: Boolean = false,
+    @Json(name = "is_lost") val isLost: Boolean = false,
+    @Json(name = "color") val color: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class StageConfigInDto(
+    @Json(name = "stages") val stages: List<StageConfigItemInDto>,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmModels.kt
@@ -214,3 +214,114 @@ internal fun LeadScoreRulesDto.toDomain(): LeadScoreRules = LeadScoreRules(
     maxScore = maxScore,
     updatedAt = updatedAt,
 )
+
+
+// ── CRM-AND-OPP: forecast / quota / pipeline-report / contact-role domain + mappers ──
+
+/** A contact linked to an opportunity in a buying role (OPP-004). */
+data class OppContactRole(
+    val oppId: String,
+    val contactRef: String,
+    val contactRole: String,
+    val ownerSub: String,
+    val createdAt: Long,
+) {
+    /** Human label for the role key (title-cased, de-underscored). */
+    val roleLabel: String
+        get() = contactRole.split('_')
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { part -> part.replaceFirstChar { it.uppercaseChar() } }
+            .ifBlank { "—" }
+}
+
+/** A rep's forecast worksheet for one period (OPP-005). */
+data class ForecastWorksheet(
+    val userSub: String,
+    val periodKey: String,
+    val committedCents: Long,
+    val bestCaseCents: Long,
+    val pipelineCents: Long,
+    val closedCents: Long,
+    val quotaCents: Long,
+    val attainmentPct: Int,
+    val notes: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+/** A per-stage row in the pipeline funnel report (OPP-006). Implements [ForecastMath.StageMetricLike]. */
+data class PipelineStageMetric(
+    override val stage: String,
+    val label: String,
+    override val count: Int,
+    override val totalAmountCents: Long,
+    override val weightedAmountCents: Long,
+    val avgCloseDate: Long?,
+) : ForecastMath.StageMetricLike
+
+/** The full pipeline funnel report (OPP-006). */
+data class PipelineReport(
+    val stages: List<PipelineStageMetric>,
+    val totalAmountCents: Long,
+    val totalWeightedCents: Long,
+    val generatedAt: Long,
+)
+
+/** A sales quota target for a rep + period (OPP-005, admin-set). */
+data class SalesQuota(
+    val userSub: String,
+    val periodType: String,
+    val periodKey: String,
+    val targetAmountCents: Long,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val setBySub: String,
+)
+
+internal fun OppContactRoleOutDto.toDomain(): OppContactRole = OppContactRole(
+    oppId = oppId,
+    contactRef = contactRef,
+    contactRole = contactRole,
+    ownerSub = ownerSub,
+    createdAt = createdAt,
+)
+
+internal fun ForecastWorksheetOutDto.toDomain(): ForecastWorksheet = ForecastWorksheet(
+    userSub = userSub,
+    periodKey = periodKey,
+    committedCents = committedCents,
+    bestCaseCents = bestCaseCents,
+    pipelineCents = pipelineCents,
+    closedCents = closedCents,
+    quotaCents = quotaCents,
+    attainmentPct = attainmentPct,
+    notes = notes,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+internal fun PipelineStageMetricDto.toDomain(): PipelineStageMetric = PipelineStageMetric(
+    stage = stage,
+    label = label.ifBlank { CrmSalesMath.stageLabel(stage) },
+    count = count,
+    totalAmountCents = totalAmountCents,
+    weightedAmountCents = weightedAmountCents,
+    avgCloseDate = avgCloseDate,
+)
+
+internal fun PipelineReportOutDto.toDomain(): PipelineReport = PipelineReport(
+    stages = stages.map { it.toDomain() },
+    totalAmountCents = totalAmountCents,
+    totalWeightedCents = totalWeightedCents,
+    generatedAt = generatedAt,
+)
+
+internal fun SalesQuotaOutDto.toDomain(): SalesQuota = SalesQuota(
+    userSub = userSub,
+    periodType = periodType,
+    periodKey = periodKey,
+    targetAmountCents = targetAmountCents,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    setBySub = setBySub,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmRepository.kt
@@ -227,12 +227,62 @@ class LeadsRepositoryImpl @Inject constructor(
 
 // ───────────────────────────  SALES  ────────────────────────────────
 
+/** A forecast worksheet + module/forbidden flags (degrade-on-404/403). */
+data class ForecastResult(
+    val worksheet: ForecastWorksheet?,
+    val moduleDisabled: Boolean = false,
+)
+
+/** A pipeline report + module/forbidden flags (degrade-on-404/503/403). */
+data class PipelineReportResult(
+    val report: PipelineReport?,
+    val moduleDisabled: Boolean = false,
+    val forbidden: Boolean = false,
+)
+
+/** A user's quota list + module/forbidden flags (admin; degrade-on-404/503/403). */
+data class QuotaListResult(
+    val quotas: List<SalesQuota>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+    val forbidden: Boolean = false,
+)
+
 interface SalesRepository {
     /** One combined pull for the pipeline board: feature status + stages + opportunities. */
     suspend fun pipeline(): ApiResult<PipelineSnapshot>
-    suspend fun getOpportunity(oppId: String): ApiResult<Opportunity>
+    suspend fun getOpportunity(oppId: String, includeContacts: Boolean = false): ApiResult<Opportunity>
     suspend fun create(body: OpportunityCreateInDto): ApiResult<Opportunity>
     suspend fun moveStage(oppId: String, stage: String): ApiResult<Opportunity>
+    suspend fun delete(oppId: String): ApiResult<Unit>
+
+    // OPP-004: contact roles
+    suspend fun listContactRoles(oppId: String): ApiResult<List<OppContactRole>>
+    suspend fun addContactRole(oppId: String, contactRef: String, contactRole: String): ApiResult<OppContactRole>
+    suspend fun removeContactRole(oppId: String, contactRef: String): ApiResult<Unit>
+
+    // OPP-005: forecast worksheet (degrade-on-404)
+    suspend fun getForecast(periodKey: String): ApiResult<ForecastResult>
+    suspend fun upsertForecast(
+        periodKey: String,
+        committedCents: Long,
+        bestCaseCents: Long,
+        pipelineCents: Long,
+        notes: String?,
+    ): ApiResult<ForecastWorksheet>
+
+    // OPP-006: pipeline report (per-rep + admin cross-user)
+    suspend fun pipelineReport(fromTs: Long? = null, toTs: Long? = null): ApiResult<PipelineReportResult>
+    suspend fun adminPipelineReport(fromTs: Long? = null, toTs: Long? = null): ApiResult<PipelineReportResult>
+
+    // OPP-005: admin quota (server 403 for non-admins)
+    suspend fun listUserQuotas(userSub: String): ApiResult<QuotaListResult>
+    suspend fun setQuota(
+        userSub: String,
+        periodType: String,
+        periodKey: String,
+        targetAmountCents: Long,
+    ): ApiResult<SalesQuota>
 }
 
 @Singleton
@@ -268,9 +318,10 @@ class SalesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getOpportunity(oppId: String): ApiResult<Opportunity> = withContext(io) {
-        call { api.getOpportunity(oppId).toDomain() }
-    }
+    override suspend fun getOpportunity(oppId: String, includeContacts: Boolean): ApiResult<Opportunity> =
+        withContext(io) {
+            call { api.getOpportunity(oppId, includeContacts.takeIf { it }).toDomain() }
+        }
 
     override suspend fun create(body: OpportunityCreateInDto): ApiResult<Opportunity> = withContext(io) {
         call { api.createOpportunity(body).toDomain() }
@@ -283,6 +334,132 @@ class SalesRepositoryImpl @Inject constructor(
                 OpportunityUpdateInDto(
                     stage = stage,
                     probability = CrmSalesMath.defaultProbabilityFor(stage),
+                ),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun delete(oppId: String): ApiResult<Unit> = withContext(io) {
+        call { api.deleteOpportunity(oppId) }
+    }
+
+    // ── Contact roles (OPP-004) ──────────────────────────────────────────────
+
+    override suspend fun listContactRoles(oppId: String): ApiResult<List<OppContactRole>> = withContext(io) {
+        when (val r = call { api.listContactRoles(oppId) }) {
+            is ApiResult.Success -> ApiResult.Success(r.data.map { it.toDomain() })
+            is ApiResult.Failure ->
+                if (r.error.status == 404 || r.error.status == 503) ApiResult.Success(emptyList()) else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun addContactRole(
+        oppId: String,
+        contactRef: String,
+        contactRole: String,
+    ): ApiResult<OppContactRole> = withContext(io) {
+        call { api.addContactRole(oppId, OppContactRoleInDto(contactRef, contactRole)).toDomain() }
+    }
+
+    override suspend fun removeContactRole(oppId: String, contactRef: String): ApiResult<Unit> = withContext(io) {
+        call { api.removeContactRole(oppId, contactRef) }
+    }
+
+    // ── Forecast worksheet (OPP-005) ─────────────────────────────────────────
+
+    override suspend fun getForecast(periodKey: String): ApiResult<ForecastResult> = withContext(io) {
+        when (val r = call { api.getForecast(periodKey) }) {
+            is ApiResult.Success -> ApiResult.Success(ForecastResult(r.data.toDomain()))
+            is ApiResult.Failure ->
+                when (r.error.status) {
+                    // 404 = no worksheet yet OR module off; 503 = module off. Degrade to an empty, editable worksheet.
+                    404, 503 -> ApiResult.Success(ForecastResult(null, moduleDisabled = r.error.status == 503))
+                    else -> r
+                }
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun upsertForecast(
+        periodKey: String,
+        committedCents: Long,
+        bestCaseCents: Long,
+        pipelineCents: Long,
+        notes: String?,
+    ): ApiResult<ForecastWorksheet> = withContext(io) {
+        call {
+            api.upsertForecast(
+                periodKey,
+                ForecastWorksheetInDto(
+                    committedCents = maxOf(0L, committedCents),
+                    bestCaseCents = maxOf(0L, bestCaseCents),
+                    pipelineCents = maxOf(0L, pipelineCents),
+                    notes = notes?.ifBlank { null },
+                ),
+            ).toDomain()
+        }
+    }
+
+    // ── Pipeline report (OPP-006) ────────────────────────────────────────────
+
+    override suspend fun pipelineReport(fromTs: Long?, toTs: Long?): ApiResult<PipelineReportResult> =
+        withContext(io) {
+            when (val r = call { api.getPipelineReport(fromTs, toTs) }) {
+                is ApiResult.Success -> ApiResult.Success(PipelineReportResult(r.data.toDomain()))
+                is ApiResult.Failure ->
+                    when (r.error.status) {
+                        404, 503 -> ApiResult.Success(PipelineReportResult(null, moduleDisabled = true))
+                        403 -> ApiResult.Success(PipelineReportResult(null, forbidden = true))
+                        else -> r
+                    }
+                is ApiResult.NetworkError -> r
+            }
+        }
+
+    override suspend fun adminPipelineReport(fromTs: Long?, toTs: Long?): ApiResult<PipelineReportResult> =
+        withContext(io) {
+            when (val r = call { api.getAdminPipelineReport(fromTs, toTs) }) {
+                is ApiResult.Success -> ApiResult.Success(PipelineReportResult(r.data.toDomain()))
+                is ApiResult.Failure ->
+                    when (r.error.status) {
+                        404, 503 -> ApiResult.Success(PipelineReportResult(null, moduleDisabled = true))
+                        403 -> ApiResult.Success(PipelineReportResult(null, forbidden = true))
+                        else -> r
+                    }
+                is ApiResult.NetworkError -> r
+            }
+        }
+
+    // ── Admin quota (OPP-005) ────────────────────────────────────────────────
+
+    override suspend fun listUserQuotas(userSub: String): ApiResult<QuotaListResult> = withContext(io) {
+        when (val r = call { api.listUserQuotas(userSub) }) {
+            is ApiResult.Success ->
+                ApiResult.Success(QuotaListResult(r.data.items.map { it.toDomain() }, r.data.nextCursor))
+            is ApiResult.Failure ->
+                when (r.error.status) {
+                    404, 503 -> ApiResult.Success(QuotaListResult(emptyList(), null, moduleDisabled = true))
+                    403 -> ApiResult.Success(QuotaListResult(emptyList(), null, forbidden = true))
+                    else -> r
+                }
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun setQuota(
+        userSub: String,
+        periodType: String,
+        periodKey: String,
+        targetAmountCents: Long,
+    ): ApiResult<SalesQuota> = withContext(io) {
+        call {
+            api.setQuota(
+                SalesQuotaInDto(
+                    userSub = userSub,
+                    periodType = periodType,
+                    periodKey = periodKey,
+                    targetAmountCents = maxOf(0L, targetAmountCents),
                 ),
             ).toDomain()
         }
@@ -314,3 +491,4 @@ class SalesRepositoryImpl @Inject constructor(
 
 /** Small helper for callers that need the [ApiError] status without a `when`. */
 internal fun ApiResult<*>.statusOrNull(): Int? = (this as? ApiResult.Failure)?.error?.status
+

--- a/android/app/src/main/java/com/testlogon/android/data/crm/ForecastMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/ForecastMath.kt
@@ -1,0 +1,133 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CRM-AND-OPP — PURE, framework-free logic for the sales FORECAST + QUOTA surface (OPP-005/006). No
+ * Android / java.time types, so every function here is JVM-unit-testable (mirrors the [CrmSalesMath]
+ * idiom). Complements [CrmSalesMath] (which owns stage classification + per-opp weighting); this file
+ * owns the forecast-worksheet roll-ups (committed / best-case / pipeline / gap-to-quota) and the
+ * quota-attainment percentage.
+ *
+ * Degrade, never throw: null / malformed / negative inputs are treated as zero rather than raising, so
+ * a 404 (module disabled) or dev-host drift renders cleanly.
+ */
+object ForecastMath {
+
+    /**
+     * Quota-attainment as a WHOLE percentage of [closedCents] against [quotaCents], rounded half-up.
+     *
+     * A non-positive quota degrades to 0 (nothing to attain against — avoids divide-by-zero). Negative
+     * closed degrades to 0. The result is NOT capped at 100 (a rep can exceed quota, which the UI shows).
+     */
+    fun attainmentPct(closedCents: Long, quotaCents: Long): Int {
+        if (quotaCents <= 0L) return 0
+        val closed = maxOf(0L, closedCents)
+        return ((closed.toDouble() / quotaCents.toDouble()) * 100.0 + 0.5).toInt()
+    }
+
+    /**
+     * Remaining amount to reach quota: max(0, quota - closed). Zero once quota is met or exceeded, and
+     * zero for a non-positive quota (nothing to close).
+     */
+    fun gapToQuotaCents(closedCents: Long, quotaCents: Long): Long {
+        if (quotaCents <= 0L) return 0L
+        val closed = maxOf(0L, closedCents)
+        return maxOf(0L, quotaCents - closed)
+    }
+
+    /**
+     * Coverage ratio: how many multiples of the remaining quota gap the open pipeline covers, as a whole
+     * percentage. E.g. gap $10k, pipeline $30k -> 300%. Zero gap (quota met) -> 0 (nothing to cover).
+     * Non-positive quota -> 0.
+     */
+    fun pipelineCoveragePct(pipelineCents: Long, closedCents: Long, quotaCents: Long): Int {
+        val gap = gapToQuotaCents(closedCents, quotaCents)
+        if (gap <= 0L) return 0
+        val pipeline = maxOf(0L, pipelineCents)
+        return ((pipeline.toDouble() / gap.toDouble()) * 100.0 + 0.5).toInt()
+    }
+
+    /**
+     * A derived forecast roll-up combining a worksheet's rep-entered figures with the closed / quota
+     * figures the server computes. Everything is clamped non-negative.
+     */
+    data class ForecastRollup(
+        val committedCents: Long,
+        val bestCaseCents: Long,
+        val pipelineCents: Long,
+        val closedCents: Long,
+        val quotaCents: Long,
+    ) {
+        /** Committed + already-closed — the "call number" a rep would commit to. */
+        val commitTotalCents: Long get() = committedCents + closedCents
+
+        /** Best-case + already-closed — the optimistic ceiling. */
+        val bestCaseTotalCents: Long get() = bestCaseCents + closedCents
+
+        val attainmentPct: Int get() = attainmentPct(closedCents, quotaCents)
+        val gapToQuotaCents: Long get() = gapToQuotaCents(closedCents, quotaCents)
+        val pipelineCoveragePct: Int get() = pipelineCoveragePct(pipelineCents, closedCents, quotaCents)
+
+        /** True once the committed forecast (closed + committed) reaches quota. */
+        val committedMeetsQuota: Boolean get() = quotaCents > 0L && commitTotalCents >= quotaCents
+    }
+
+    /** Build a [ForecastRollup], clamping every input non-negative (degrade on bad server drift). */
+    fun rollup(
+        committedCents: Long,
+        bestCaseCents: Long,
+        pipelineCents: Long,
+        closedCents: Long,
+        quotaCents: Long,
+    ): ForecastRollup = ForecastRollup(
+        committedCents = maxOf(0L, committedCents),
+        bestCaseCents = maxOf(0L, bestCaseCents),
+        pipelineCents = maxOf(0L, pipelineCents),
+        closedCents = maxOf(0L, closedCents),
+        quotaCents = maxOf(0L, quotaCents),
+    )
+
+    // ── Pipeline-report roll-ups (OPP-006) ──────────────────────────────────
+
+    /** Minimal shape the report maths need from one stage row (keeps the maths DTO/domain-agnostic). */
+    interface StageMetricLike {
+        val stage: String?
+        val count: Int
+        val totalAmountCents: Long
+        val weightedAmountCents: Long
+    }
+
+    /** Sum of un-weighted amount across OPEN stages only (closed_won / closed_lost excluded). */
+    fun openTotalAmountCents(rows: List<StageMetricLike>): Long =
+        rows.asSequence()
+            .filter { CrmSalesMath.isOpenStage(it.stage) }
+            .sumOf { maxOf(0L, it.totalAmountCents) }
+
+    /** Sum of weighted amount across OPEN stages only. */
+    fun openWeightedAmountCents(rows: List<StageMetricLike>): Long =
+        rows.asSequence()
+            .filter { CrmSalesMath.isOpenStage(it.stage) }
+            .sumOf { maxOf(0L, it.weightedAmountCents) }
+
+    /** Total realised (closed_won) amount across the report rows. */
+    fun wonAmountCents(rows: List<StageMetricLike>): Long =
+        rows.asSequence()
+            .filter { CrmSalesMath.isWonStage(it.stage) }
+            .sumOf { maxOf(0L, it.totalAmountCents) }
+
+    /** Total open-opportunity COUNT across the report rows. */
+    fun openCount(rows: List<StageMetricLike>): Int =
+        rows.asSequence()
+            .filter { CrmSalesMath.isOpenStage(it.stage) }
+            .sumOf { maxOf(0, it.count) }
+
+    /**
+     * Funnel conversion for one stage as a whole percentage of the TOTAL open+won count that has reached
+     * at least this stage. Simplistic (share of pipeline by count) — enough for a bar-width in the UI.
+     * Zero total -> 0.
+     */
+    fun stageSharePct(stageCount: Int, totalCount: Int): Int {
+        if (totalCount <= 0) return 0
+        val c = maxOf(0, stageCount)
+        return ((c.toDouble() / totalCount.toDouble()) * 100.0 + 0.5).toInt()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/SalesApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/SalesApi.kt
@@ -1,21 +1,22 @@
 package com.testlogon.android.data.crm
 
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 /**
- * CRM-AND-1 — Retrofit interface for SuiteCRM Opportunities (OPP-*). Router prefix /ui/sales.
+ * CRM-AND-1 / CRM-AND-OPP — Retrofit interface for SuiteCRM Opportunities (OPP-*). Router prefixes
+ * /ui/sales (rep) and /ui/admin/sales (admin).
  *
  * Backend gates on S.sales_pipeline_enabled — endpoints 503 when off (feature-status never 503s); the
- * repository treats 503/404 as a degraded/empty result. Verified against
+ * repository treats 503/404 as a degraded/empty result. Admin endpoints additionally 403 for
+ * non-admins (surfaced as a "forbidden" empty state). Verified against
  * frontend/src/api/endpoints/opportunities.ts.
- *
- * MVP scope: feature-status / stages / list / get / create / update (stage move). Forecast / quota /
- * reports / contact-roles are deferred to phase-2 (noted in the repository).
  */
 interface SalesApi {
 
@@ -25,6 +26,10 @@ interface SalesApi {
     @GET("ui/sales/stages")
     suspend fun listStages(): StageConfigOutDto
 
+    // Admin: replace the stage list (PUT /ui/admin/sales/stages — 403 for non-admins).
+    @PUT("ui/admin/sales/stages")
+    suspend fun updateStages(@Body body: StageConfigInDto): StageConfigOutDto
+
     @GET("ui/sales/opportunities")
     suspend fun listOpportunities(
         @Query("stage") stage: String? = null,
@@ -33,7 +38,10 @@ interface SalesApi {
     ): OpportunityListRespDto
 
     @GET("ui/sales/opportunities/{oppId}")
-    suspend fun getOpportunity(@Path("oppId") oppId: String): OpportunityOutDto
+    suspend fun getOpportunity(
+        @Path("oppId") oppId: String,
+        @Query("include_contacts") includeContacts: Boolean? = null,
+    ): OpportunityOutDto
 
     @POST("ui/sales/opportunities")
     suspend fun createOpportunity(@Body body: OpportunityCreateInDto): OpportunityOutDto
@@ -43,4 +51,61 @@ interface SalesApi {
         @Path("oppId") oppId: String,
         @Body body: OpportunityUpdateInDto,
     ): OpportunityOutDto
+
+    @DELETE("ui/sales/opportunities/{oppId}")
+    suspend fun deleteOpportunity(@Path("oppId") oppId: String)
+
+    // ── OPP-004: Contact-role junction ────────────────────────────────────────
+
+    @POST("ui/sales/opportunities/{oppId}/contacts")
+    suspend fun addContactRole(
+        @Path("oppId") oppId: String,
+        @Body body: OppContactRoleInDto,
+    ): OppContactRoleOutDto
+
+    @GET("ui/sales/opportunities/{oppId}/contacts")
+    suspend fun listContactRoles(@Path("oppId") oppId: String): List<OppContactRoleOutDto>
+
+    @DELETE("ui/sales/opportunities/{oppId}/contacts/{contactRef}")
+    suspend fun removeContactRole(
+        @Path("oppId") oppId: String,
+        @Path("contactRef") contactRef: String,
+    )
+
+    // ── OPP-005: Forecast worksheet ───────────────────────────────────────────
+
+    @GET("ui/sales/forecast/{periodKey}")
+    suspend fun getForecast(@Path("periodKey") periodKey: String): ForecastWorksheetOutDto
+
+    @PUT("ui/sales/forecast/{periodKey}")
+    suspend fun upsertForecast(
+        @Path("periodKey") periodKey: String,
+        @Body body: ForecastWorksheetInDto,
+    ): ForecastWorksheetOutDto
+
+    // ── OPP-006: Pipeline report ──────────────────────────────────────────────
+
+    @GET("ui/sales/reports/pipeline")
+    suspend fun getPipelineReport(
+        @Query("from_ts") fromTs: Long? = null,
+        @Query("to_ts") toTs: Long? = null,
+    ): PipelineReportOutDto
+
+    @GET("ui/admin/sales/reports/pipeline")
+    suspend fun getAdminPipelineReport(
+        @Query("from_ts") fromTs: Long? = null,
+        @Query("to_ts") toTs: Long? = null,
+    ): PipelineReportOutDto
+
+    // ── OPP-005: Admin quota ──────────────────────────────────────────────────
+
+    @POST("ui/admin/sales/quotas")
+    suspend fun setQuota(@Body body: SalesQuotaInDto): SalesQuotaOutDto
+
+    @GET("ui/admin/sales/quotas/{userSub}")
+    suspend fun listUserQuotas(
+        @Path("userSub") userSub: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): SalesQuotaListOutDto
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/PipelineScreen.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/PipelineScreen.kt
@@ -60,6 +60,11 @@ object CrmPipelineTestTags {
 @Composable
 fun PipelineRoute(
     onBack: () -> Unit,
+    onOpenForecast: () -> Unit = {},
+    onOpenReport: () -> Unit = {},
+    onOpenTeamReport: () -> Unit = {},
+    onOpenQuotas: () -> Unit = {},
+    onOpenContactRoles: (oppId: String) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: PipelineViewModel = hiltViewModel(),
 ) {
@@ -73,6 +78,11 @@ fun PipelineRoute(
         onCreate = viewModel::createOpportunity,
         onClearCreateError = viewModel::clearCreateError,
         onClearActionMessage = viewModel::clearActionMessage,
+        onOpenForecast = onOpenForecast,
+        onOpenReport = onOpenReport,
+        onOpenTeamReport = onOpenTeamReport,
+        onOpenQuotas = onOpenQuotas,
+        onOpenContactRoles = onOpenContactRoles,
         modifier = modifier,
     )
 }
@@ -87,8 +97,14 @@ fun PipelineScreen(
     onCreate: (name: String, stage: String, amountDollars: String, closeDate: Long, onCreated: () -> Unit) -> Unit,
     onClearCreateError: () -> Unit,
     onClearActionMessage: () -> Unit,
+    onOpenForecast: () -> Unit = {},
+    onOpenReport: () -> Unit = {},
+    onOpenTeamReport: () -> Unit = {},
+    onOpenQuotas: () -> Unit = {},
+    onOpenContactRoles: (oppId: String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
+    var overflowOpen by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     var showCreate by remember { mutableStateOf(false) }
 
@@ -108,6 +124,29 @@ fun PipelineScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { overflowOpen = true }) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = "More")
+                    }
+                    DropdownMenu(expanded = overflowOpen, onDismissRequest = { overflowOpen = false }) {
+                        DropdownMenuItem(
+                            text = { Text("Forecast worksheet") },
+                            onClick = { overflowOpen = false; onOpenForecast() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Pipeline report") },
+                            onClick = { overflowOpen = false; onOpenReport() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Team report (admin)") },
+                            onClick = { overflowOpen = false; onOpenTeamReport() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Sales quotas (admin)") },
+                            onClick = { overflowOpen = false; onOpenQuotas() },
+                        )
                     }
                 },
             )
@@ -152,6 +191,7 @@ fun PipelineScreen(
                                     stageKeys = state.columns.map { it.stageKey },
                                     moving = state.movingOppId == opp.oppId,
                                     onMoveStage = { newStage -> onMoveStage(opp.oppId, newStage) },
+                                    onOpenContactRoles = { onOpenContactRoles(opp.oppId) },
                                 )
                             }
                         }
@@ -230,6 +270,7 @@ private fun OpportunityCard(
     stageKeys: List<String>,
     moving: Boolean,
     onMoveStage: (String) -> Unit,
+    onOpenContactRoles: () -> Unit = {},
 ) {
     var menuOpen by remember { mutableStateOf(false) }
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -262,6 +303,14 @@ private fun OpportunityCard(
                 Icon(Icons.Filled.MoreVert, contentDescription = "Move stage")
             }
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("Contact roles") },
+                    onClick = {
+                        menuOpen = false
+                        onOpenContactRoles()
+                    },
+                )
+                androidx.compose.material3.HorizontalDivider()
                 stageKeys.filter { it != opp.stage }.forEach { stage ->
                     DropdownMenuItem(
                         text = { Text(CrmSalesMath.stageLabel(stage)) },

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/SalesOpsScreens.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/SalesOpsScreens.kt
@@ -1,0 +1,1062 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.data.crm.CrmSalesMath
+import com.testlogon.android.data.crm.ForecastMath
+import com.testlogon.android.data.crm.ForecastWorksheet
+import com.testlogon.android.data.crm.OppContactRole
+import com.testlogon.android.data.crm.PipelineReport
+import com.testlogon.android.data.crm.SalesQuota
+import com.testlogon.android.data.crm.SalesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// ══════════════════════════════════════════════════════════════════════════
+//  Shared helpers
+// ══════════════════════════════════════════════════════════════════════════
+
+/** "1,234.56" / "1234" -> cents; null on garbage. */
+internal fun parseDollarsToCentsOrNull(raw: String): Long? {
+    val cleaned = raw.trim().replace(",", "").removePrefix("$")
+    if (cleaned.isBlank()) return null
+    val value = cleaned.toDoubleOrNull() ?: return null
+    if (value < 0) return null
+    return Math.round(value * 100.0)
+}
+
+private fun centsToDollarField(cents: Long): String =
+    if (cents <= 0L) "" else (cents / 100.0).toString()
+
+// ══════════════════════════════════════════════════════════════════════════
+//  OPP-005 — Forecast worksheet
+// ══════════════════════════════════════════════════════════════════════════
+
+object CrmForecastTestTags {
+    const val SCREEN = "crm_forecast_screen"
+    const val CONTENT = "crm_forecast_content"
+    const val SAVE = "crm_forecast_save"
+}
+
+data class ForecastUiState(
+    val phase: Phase = Phase.Loading,
+    val periodKey: String = "",
+    val committed: String = "",
+    val bestCase: String = "",
+    val pipeline: String = "",
+    val notes: String = "",
+    val closedCents: Long = 0,
+    val quotaCents: Long = 0,
+    val moduleDisabled: Boolean = false,
+    val saving: Boolean = false,
+    val message: String? = null,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    val rollup: ForecastMath.ForecastRollup
+        get() = ForecastMath.rollup(
+            committedCents = parseDollarsToCentsOrNull(committed) ?: 0L,
+            bestCaseCents = parseDollarsToCentsOrNull(bestCase) ?: 0L,
+            pipelineCents = parseDollarsToCentsOrNull(pipeline) ?: 0L,
+            closedCents = closedCents,
+            quotaCents = quotaCents,
+        )
+}
+
+/**
+ * CRM-AND-OPP — the rep forecast worksheet (GET/PUT /ui/sales/forecast/{period}). The period key is
+ * defaulted to the current YYYY-MM if not supplied. Committed / best-case / pipeline are rep-entered;
+ * closed / quota / attainment are server-computed and shown read-only. 404 (no worksheet yet) degrades
+ * to an empty, editable worksheet; 503 (module off) shows a banner.
+ */
+@HiltViewModel
+class ForecastViewModel @Inject constructor(
+    private val repository: SalesRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val periodKey: String =
+        savedStateHandle.get<String>(ARG_PERIOD_KEY)?.takeIf { it.isNotBlank() } ?: defaultPeriodKey()
+
+    private val _uiState = MutableStateFlow(ForecastUiState(periodKey = periodKey))
+    val uiState: StateFlow<ForecastUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update { it.copy(phase = ForecastUiState.Phase.Loading) }
+        viewModelScope.launch {
+            when (val r = repository.getForecast(periodKey)) {
+                is ApiResult.Success -> _uiState.update {
+                    val w = r.data.worksheet
+                    it.copy(
+                        phase = ForecastUiState.Phase.Content,
+                        committed = w?.let { centsToDollarField(it.committedCents) } ?: it.committed,
+                        bestCase = w?.let { centsToDollarField(it.bestCaseCents) } ?: it.bestCase,
+                        pipeline = w?.let { centsToDollarField(it.pipelineCents) } ?: it.pipeline,
+                        notes = w?.notes ?: it.notes,
+                        closedCents = w?.closedCents ?: 0L,
+                        quotaCents = w?.quotaCents ?: 0L,
+                        moduleDisabled = r.data.moduleDisabled,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = ForecastUiState.Phase.Error, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = ForecastUiState.Phase.Error, errorMessage = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun onCommittedChange(v: String) = _uiState.update { it.copy(committed = v) }
+    fun onBestCaseChange(v: String) = _uiState.update { it.copy(bestCase = v) }
+    fun onPipelineChange(v: String) = _uiState.update { it.copy(pipeline = v) }
+    fun onNotesChange(v: String) = _uiState.update { it.copy(notes = v) }
+
+    fun save() {
+        val s = _uiState.value
+        _uiState.update { it.copy(saving = true, message = null) }
+        viewModelScope.launch {
+            val result = repository.upsertForecast(
+                periodKey = periodKey,
+                committedCents = parseDollarsToCentsOrNull(s.committed) ?: 0L,
+                bestCaseCents = parseDollarsToCentsOrNull(s.bestCase) ?: 0L,
+                pipelineCents = parseDollarsToCentsOrNull(s.pipeline) ?: 0L,
+                notes = s.notes,
+            )
+            when (result) {
+                is ApiResult.Success -> _uiState.update {
+                    val w = result.data
+                    it.copy(
+                        saving = false,
+                        closedCents = w.closedCents,
+                        quotaCents = w.quotaCents,
+                        message = "Forecast saved.",
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(saving = false, message = result.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(saving = false, message = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearMessage() = _uiState.update { it.copy(message = null) }
+
+    companion object {
+        const val ARG_PERIOD_KEY = "periodKey"
+
+        /** Current period as YYYY-MM using pure arithmetic (no java.time to keep it deterministic-ish). */
+        private fun defaultPeriodKey(): String {
+            val millis = System.currentTimeMillis()
+            val days = millis / 86_400_000L
+            // Days since 1970-01-01; approximate year/month via civil-from-days.
+            var z = days + 719_468
+            val era = (if (z >= 0) z else z - 146_096) / 146_097
+            val doe = z - era * 146_097
+            val yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365
+            val y = yoe + era * 400
+            val doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+            val mp = (5 * doy + 2) / 153
+            val m = if (mp < 10) mp + 3 else mp - 9
+            val year = if (m <= 2) y + 1 else y
+            return "%04d-%02d".format(year, m)
+        }
+    }
+}
+
+@Composable
+fun ForecastRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ForecastViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    ForecastScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onCommittedChange = viewModel::onCommittedChange,
+        onBestCaseChange = viewModel::onBestCaseChange,
+        onPipelineChange = viewModel::onPipelineChange,
+        onNotesChange = viewModel::onNotesChange,
+        onSave = viewModel::save,
+        onClearMessage = viewModel::clearMessage,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ForecastScreen(
+    state: ForecastUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onCommittedChange: (String) -> Unit,
+    onBestCaseChange: (String) -> Unit,
+    onPipelineChange: (String) -> Unit,
+    onNotesChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onClearMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(state.message) {
+        state.message?.let {
+            snackbarHostState.showSnackbar(it)
+            onClearMessage()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmForecastTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Forecast · ${state.periodKey}") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            ForecastUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            ForecastUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load the forecast.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            ForecastUiState.Phase.Content -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+                    .testTag(CrmForecastTestTags.CONTENT),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                if (state.moduleDisabled) {
+                    InfoBanner("The sales pipeline is not enabled for this account.")
+                }
+
+                val r = state.rollup
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("Quota attainment", style = MaterialTheme.typography.titleMedium)
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                            KpiCell(CrmSalesMath.formatCents(r.closedCents), "Closed")
+                            KpiCell(CrmSalesMath.formatCents(r.quotaCents), "Quota")
+                            KpiCell("${r.attainmentPct}%", "Attainment")
+                        }
+                        LinearProgressIndicator(
+                            progress = { (r.attainmentPct.coerceIn(0, 100)) / 100f },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Text(
+                            "Gap to quota: ${CrmSalesMath.formatCents(r.gapToQuotaCents)} · " +
+                                "Commit total: ${CrmSalesMath.formatCents(r.commitTotalCents)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                DollarField(state.committed, onCommittedChange, "Committed")
+                DollarField(state.bestCase, onBestCaseChange, "Best case")
+                DollarField(state.pipeline, onPipelineChange, "Pipeline")
+                OutlinedTextField(
+                    value = state.notes,
+                    onValueChange = onNotesChange,
+                    label = { Text("Notes") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Button(
+                    onClick = onSave,
+                    enabled = !state.saving && !state.moduleDisabled,
+                    modifier = Modifier.fillMaxWidth().testTag(CrmForecastTestTags.SAVE),
+                ) { Text(if (state.saving) "Saving…" else "Save forecast") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DollarField(value: String, onChange: (String) -> Unit, label: String) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onChange,
+        label = { Text(label) },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        prefix = { Text("$") },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun KpiCell(value: String, label: String) {
+    Column {
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+//  OPP-006 — Pipeline report (per-rep + admin)
+// ══════════════════════════════════════════════════════════════════════════
+
+object CrmPipelineReportTestTags {
+    const val SCREEN = "crm_pipeline_report_screen"
+    const val CONTENT = "crm_pipeline_report_content"
+}
+
+data class PipelineReportUiState(
+    val phase: Phase = Phase.Loading,
+    val admin: Boolean = false,
+    val report: PipelineReport? = null,
+    val moduleDisabled: Boolean = false,
+    val forbidden: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-OPP — pipeline funnel report (GET /ui/sales/reports/pipeline, or the admin cross-user variant
+ * /ui/admin/sales/reports/pipeline when [admin] is set). Admin variant 403s for non-admins → a
+ * "forbidden" empty state; 404/503 → module banner.
+ */
+@HiltViewModel
+class PipelineReportViewModel @Inject constructor(
+    private val repository: SalesRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val admin: Boolean =
+        savedStateHandle.get<String>(ARG_ADMIN)?.equals("true", ignoreCase = true) == true
+
+    private val _uiState = MutableStateFlow(PipelineReportUiState(admin = admin))
+    val uiState: StateFlow<PipelineReportUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update { it.copy(phase = PipelineReportUiState.Phase.Loading, forbidden = false) }
+        viewModelScope.launch {
+            val r = if (admin) repository.adminPipelineReport() else repository.pipelineReport()
+            when (r) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = PipelineReportUiState.Phase.Content,
+                        report = r.data.report,
+                        moduleDisabled = r.data.moduleDisabled,
+                        forbidden = r.data.forbidden,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = PipelineReportUiState.Phase.Error, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = PipelineReportUiState.Phase.Error, errorMessage = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_ADMIN = "admin"
+    }
+}
+
+@Composable
+fun PipelineReportRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PipelineReportViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    PipelineReportScreen(state = state, onBack = onBack, onRetry = viewModel::onRetry, modifier = modifier)
+}
+
+@Composable
+fun PipelineReportScreen(
+    state: PipelineReportUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmPipelineReportTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                title = { Text(if (state.admin) "Pipeline report · Team" else "Pipeline report") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when {
+            state.phase == PipelineReportUiState.Phase.Loading ->
+                LoadingState(modifier = Modifier.padding(padding))
+            state.phase == PipelineReportUiState.Phase.Error ->
+                ErrorState(
+                    message = state.errorMessage ?: "Couldn't load the report.",
+                    onRetry = onRetry,
+                    modifier = Modifier.padding(padding),
+                )
+            state.forbidden ->
+                EmptyState(
+                    title = "Admin access required",
+                    body = "The team pipeline report is only available to administrators.",
+                    modifier = Modifier.padding(padding).fillMaxSize(),
+                )
+            state.moduleDisabled || state.report == null ->
+                EmptyState(
+                    title = "Pipeline unavailable",
+                    body = "The sales pipeline is not enabled for this account.",
+                    modifier = Modifier.padding(padding).fillMaxSize(),
+                )
+            else -> {
+                val report = state.report
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp)
+                        .testTag(CrmPipelineReportTestTags.CONTENT),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            KpiCell(CrmSalesMath.formatCents(report.totalAmountCents), "Total")
+                            KpiCell(CrmSalesMath.formatCents(report.totalWeightedCents), "Weighted")
+                            KpiCell("${ForecastMath.openCount(report.stages)}", "Open")
+                        }
+                    }
+
+                    val maxCount = report.stages.maxOfOrNull { maxOf(0, it.count) } ?: 0
+                    report.stages.forEach { row ->
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            Column(
+                                modifier = Modifier.padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                            ) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                ) {
+                                    Text(row.label, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                                    Text("${row.count}", style = MaterialTheme.typography.titleSmall)
+                                }
+                                LinearProgressIndicator(
+                                    progress = { if (maxCount <= 0) 0f else row.count.coerceAtLeast(0).toFloat() / maxCount },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                Text(
+                                    "${CrmSalesMath.formatCents(row.totalAmountCents)} · " +
+                                        "weighted ${CrmSalesMath.formatCents(row.weightedAmountCents)}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+//  OPP-004 — Opportunity contact roles
+// ══════════════════════════════════════════════════════════════════════════
+
+object CrmContactRolesTestTags {
+    const val SCREEN = "crm_contact_roles_screen"
+    const val CONTENT = "crm_contact_roles_content"
+    const val ADD = "crm_contact_roles_add"
+}
+
+/** Mirror of CONTACT_ROLES in opportunities.ts. */
+val CONTACT_ROLE_CHOICES: List<String> = listOf(
+    "decision_maker", "evaluator", "influencer", "champion",
+    "end_user", "executive_sponsor", "technical_buyer", "other",
+)
+
+data class ContactRolesUiState(
+    val phase: Phase = Phase.Loading,
+    val oppId: String = "",
+    val roles: List<OppContactRole> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val submitting: Boolean = false,
+    val message: String? = null,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-OPP — opportunity contact-roles (POST/GET/DELETE /ui/sales/opportunities/{id}/contacts).
+ * 404/503 degrades to an empty non-error list.
+ */
+@HiltViewModel
+class ContactRolesViewModel @Inject constructor(
+    private val repository: SalesRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val oppId: String = savedStateHandle.get<String>(ARG_OPP_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow(ContactRolesUiState(oppId = oppId))
+    val uiState: StateFlow<ContactRolesUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        _uiState.update { it.copy(phase = ContactRolesUiState.Phase.Loading) }
+        viewModelScope.launch {
+            when (val r = repository.listContactRoles(oppId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = ContactRolesUiState.Phase.Content,
+                        roles = r.data,
+                        moduleDisabled = r.data.isEmpty() && it.moduleDisabled,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = ContactRolesUiState.Phase.Error, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = ContactRolesUiState.Phase.Error, errorMessage = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun add(contactRef: String, contactRole: String) {
+        if (contactRef.isBlank()) {
+            _uiState.update { it.copy(message = "Contact reference is required.") }
+            return
+        }
+        _uiState.update { it.copy(submitting = true, message = null) }
+        viewModelScope.launch {
+            when (val r = repository.addContactRole(oppId, contactRef.trim(), contactRole)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(submitting = false, message = "Contact linked.") }
+                    load()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(submitting = false, message = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(submitting = false, message = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun remove(contactRef: String) {
+        _uiState.update { it.copy(message = null) }
+        viewModelScope.launch {
+            when (val r = repository.removeContactRole(oppId, contactRef)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(message = "Contact removed.") }
+                    load()
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(message = r.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(message = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun clearMessage() = _uiState.update { it.copy(message = null) }
+
+    companion object {
+        const val ARG_OPP_ID = "oppId"
+    }
+}
+
+@Composable
+fun ContactRolesRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ContactRolesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    ContactRolesScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onAdd = viewModel::add,
+        onRemove = viewModel::remove,
+        onClearMessage = viewModel::clearMessage,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ContactRolesScreen(
+    state: ContactRolesUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onAdd: (contactRef: String, role: String) -> Unit,
+    onRemove: (contactRef: String) -> Unit,
+    onClearMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(state.message) {
+        state.message?.let {
+            snackbarHostState.showSnackbar(it)
+            onClearMessage()
+        }
+    }
+    var ref by remember { mutableStateOf("") }
+    var role by remember { mutableStateOf(CONTACT_ROLE_CHOICES.first()) }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmContactRolesTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Contact roles") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            ContactRolesUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            ContactRolesUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load contact roles.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            ContactRolesUiState.Phase.Content -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+                    .testTag(CrmContactRolesTestTags.CONTENT),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("Link a contact", style = MaterialTheme.typography.titleMedium)
+                        OutlinedTextField(
+                            value = ref,
+                            onValueChange = { ref = it },
+                            label = { Text("Contact reference (party id / email)") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        RoleChooser(selected = role, onSelect = { role = it })
+                        Button(
+                            onClick = { onAdd(ref, role); ref = "" },
+                            enabled = !state.submitting,
+                            modifier = Modifier.fillMaxWidth().testTag(CrmContactRolesTestTags.ADD),
+                        ) {
+                            Icon(Icons.Filled.Add, contentDescription = null)
+                            Text(if (state.submitting) " Linking…" else " Link contact")
+                        }
+                    }
+                }
+
+                Text("Linked contacts (${state.roles.size})", style = MaterialTheme.typography.titleMedium)
+                if (state.roles.isEmpty()) {
+                    Text(
+                        "No contacts linked yet.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    state.roles.forEach { r ->
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(r.contactRef, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                                    Text(r.roleLabel, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                                IconButton(onClick = { onRemove(r.contactRef) }) {
+                                    Icon(Icons.Filled.Delete, contentDescription = "Remove contact")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoleChooser(selected: String, onSelect: (String) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("Role", style = MaterialTheme.typography.labelMedium)
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            CONTACT_ROLE_CHOICES.forEach { key ->
+                androidx.compose.material3.FilterChip(
+                    selected = key == selected,
+                    onClick = { onSelect(key) },
+                    label = {
+                        Text(
+                            key.split('_').joinToString(" ") { p -> p.replaceFirstChar { it.uppercaseChar() } },
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+//  OPP-005 — Admin quota view
+// ══════════════════════════════════════════════════════════════════════════
+
+object CrmQuotaTestTags {
+    const val SCREEN = "crm_quota_screen"
+    const val CONTENT = "crm_quota_content"
+    const val SET = "crm_quota_set"
+}
+
+val QUOTA_PERIOD_TYPES: List<String> = listOf("monthly", "quarterly", "annual")
+
+data class QuotaUiState(
+    val phase: Phase = Phase.Idle,
+    val userSub: String = "",
+    val periodType: String = "monthly",
+    val periodKey: String = "",
+    val target: String = "",
+    val quotas: List<SalesQuota> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val forbidden: Boolean = false,
+    val submitting: Boolean = false,
+    val message: String? = null,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Idle, Loading, Content, Error }
+}
+
+/**
+ * CRM-AND-OPP — admin quota view/set (POST /ui/admin/sales/quotas, GET /ui/admin/sales/quotas/{sub}).
+ * Server 403 for non-admins → a "forbidden" state (mirrors the ScoringRules admin idiom). The admin
+ * enters a target user_sub to look up / set quotas for.
+ */
+@HiltViewModel
+class QuotaViewModel @Inject constructor(
+    private val repository: SalesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(QuotaUiState())
+    val uiState: StateFlow<QuotaUiState> = _uiState.asStateFlow()
+
+    fun onUserSubChange(v: String) = _uiState.update { it.copy(userSub = v) }
+    fun onPeriodTypeChange(v: String) = _uiState.update { it.copy(periodType = v) }
+    fun onPeriodKeyChange(v: String) = _uiState.update { it.copy(periodKey = v) }
+    fun onTargetChange(v: String) = _uiState.update { it.copy(target = v) }
+
+    fun lookup() {
+        val sub = _uiState.value.userSub.trim()
+        if (sub.isBlank()) {
+            _uiState.update { it.copy(message = "Enter a user id to look up.") }
+            return
+        }
+        _uiState.update { it.copy(phase = QuotaUiState.Phase.Loading, forbidden = false) }
+        viewModelScope.launch {
+            when (val r = repository.listUserQuotas(sub)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = QuotaUiState.Phase.Content,
+                        quotas = r.data.quotas,
+                        moduleDisabled = r.data.moduleDisabled,
+                        forbidden = r.data.forbidden,
+                        errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = QuotaUiState.Phase.Error, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = QuotaUiState.Phase.Error, errorMessage = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun setQuota() {
+        val s = _uiState.value
+        val cents = parseDollarsToCentsOrNull(s.target)
+        if (s.userSub.isBlank() || s.periodKey.isBlank() || cents == null) {
+            _uiState.update { it.copy(message = "User, period key and a valid target are required.") }
+            return
+        }
+        _uiState.update { it.copy(submitting = true, message = null) }
+        viewModelScope.launch {
+            when (val r = repository.setQuota(s.userSub.trim(), s.periodType, s.periodKey.trim(), cents)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(submitting = false, message = "Quota set.") }
+                    lookup()
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(submitting = false, message = r.error.message, forbidden = r.error.status == 403)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(submitting = false, message = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    fun clearMessage() = _uiState.update { it.copy(message = null) }
+}
+
+@Composable
+fun QuotaRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: QuotaViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    QuotaScreen(
+        state = state,
+        onBack = onBack,
+        onUserSubChange = viewModel::onUserSubChange,
+        onPeriodTypeChange = viewModel::onPeriodTypeChange,
+        onPeriodKeyChange = viewModel::onPeriodKeyChange,
+        onTargetChange = viewModel::onTargetChange,
+        onLookup = viewModel::lookup,
+        onSet = viewModel::setQuota,
+        onClearMessage = viewModel::clearMessage,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun QuotaScreen(
+    state: QuotaUiState,
+    onBack: () -> Unit,
+    onUserSubChange: (String) -> Unit,
+    onPeriodTypeChange: (String) -> Unit,
+    onPeriodKeyChange: (String) -> Unit,
+    onTargetChange: (String) -> Unit,
+    onLookup: () -> Unit,
+    onSet: () -> Unit,
+    onClearMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(state.message) {
+        state.message?.let {
+            snackbarHostState.showSnackbar(it)
+            onClearMessage()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag(CrmQuotaTestTags.SCREEN),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Sales quotas") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+                .testTag(CrmQuotaTestTags.CONTENT),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (state.forbidden) {
+                EmptyState(
+                    title = "Admin access required",
+                    body = "Sales quotas can only be viewed or set by an administrator.",
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            if (state.moduleDisabled) {
+                InfoBanner("The sales pipeline is not enabled for this account.")
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Rep quota", style = MaterialTheme.typography.titleMedium)
+                    OutlinedTextField(
+                        value = state.userSub,
+                        onValueChange = onUserSubChange,
+                        label = { Text("User id (sub)") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    OutlinedButton(onClick = onLookup, modifier = Modifier.fillMaxWidth()) {
+                        Text("Look up quotas")
+                    }
+
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        QUOTA_PERIOD_TYPES.forEach { pt ->
+                            androidx.compose.material3.FilterChip(
+                                selected = pt == state.periodType,
+                                onClick = { onPeriodTypeChange(pt) },
+                                label = { Text(pt.replaceFirstChar { it.uppercaseChar() }) },
+                            )
+                        }
+                    }
+                    OutlinedTextField(
+                        value = state.periodKey,
+                        onValueChange = onPeriodKeyChange,
+                        label = { Text("Period key (e.g. 2026-Q3 / 2026-09 / 2026)") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    OutlinedTextField(
+                        value = state.target,
+                        onValueChange = onTargetChange,
+                        label = { Text("Target amount") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        prefix = { Text("$") },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Button(
+                        onClick = onSet,
+                        enabled = !state.submitting,
+                        modifier = Modifier.fillMaxWidth().testTag(CrmQuotaTestTags.SET),
+                    ) { Text(if (state.submitting) "Saving…" else "Set quota") }
+                }
+            }
+
+            when (state.phase) {
+                QuotaUiState.Phase.Loading -> Box(modifier = Modifier.fillMaxWidth()) { LoadingState() }
+                QuotaUiState.Phase.Error -> ErrorState(
+                    message = state.errorMessage ?: "Couldn't load quotas.",
+                    onRetry = onLookup,
+                )
+                QuotaUiState.Phase.Content -> {
+                    Text("Quotas (${state.quotas.size})", style = MaterialTheme.typography.titleMedium)
+                    if (state.quotas.isEmpty() && !state.forbidden) {
+                        Text(
+                            "No quotas set for this user.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        state.quotas.forEach { q ->
+                            Card(modifier = Modifier.fillMaxWidth()) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                ) {
+                                    Column {
+                                        Text("${q.periodType.replaceFirstChar { it.uppercaseChar() }} · ${q.periodKey}", fontWeight = FontWeight.Medium)
+                                        Text(
+                                            "Set by ${q.setBySub}",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                    Text(CrmSalesMath.formatCents(q.targetAmountCents), fontWeight = FontWeight.SemiBold)
+                                }
+                            }
+                        }
+                    }
+                }
+                QuotaUiState.Phase.Idle -> Unit
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
@@ -10,6 +10,13 @@ import com.testlogon.android.feature.crm.LeadDetailRoute
 import com.testlogon.android.feature.crm.LeadDetailViewModel
 import com.testlogon.android.feature.crm.LeadsListRoute
 import com.testlogon.android.feature.crm.PipelineRoute
+import com.testlogon.android.feature.crm.ForecastRoute
+import com.testlogon.android.feature.crm.ForecastViewModel
+import com.testlogon.android.feature.crm.PipelineReportRoute
+import com.testlogon.android.feature.crm.PipelineReportViewModel
+import com.testlogon.android.feature.crm.ContactRolesRoute
+import com.testlogon.android.feature.crm.ContactRolesViewModel
+import com.testlogon.android.feature.crm.QuotaRoute
 import com.testlogon.android.feature.crm.ProspectPoolRoute
 import com.testlogon.android.feature.crm.ScoringRulesRoute
 import com.testlogon.android.feature.crm.CrmProjectsRoute
@@ -38,6 +45,35 @@ data object CrmLeadDetailDest {
 /** CRM-AND-1 — the sales-pipeline board route. */
 data object CrmPipelineDest {
     const val ROUTE = "crm/pipeline"
+}
+
+/** CRM-AND-OPP — the rep forecast worksheet route; optional period_key path arg (defaults to current month). */
+data object CrmForecastDest {
+    const val ARG_PERIOD_KEY = ForecastViewModel.ARG_PERIOD_KEY
+    const val ROUTE = "crm/forecast/{$ARG_PERIOD_KEY}"
+
+    fun build(periodKey: String): String = "crm/forecast/" + Uri.encode(periodKey.ifBlank { "current" })
+}
+
+/** CRM-AND-OPP — the pipeline funnel report route; the arg is "true" for the admin cross-user variant. */
+data object CrmPipelineReportDest {
+    const val ARG_ADMIN = PipelineReportViewModel.ARG_ADMIN
+    const val ROUTE = "crm/pipeline-report/{$ARG_ADMIN}"
+
+    fun build(admin: Boolean): String = "crm/pipeline-report/" + (if (admin) "true" else "false")
+}
+
+/** CRM-AND-OPP — the opportunity contact-roles route; the arg is the STRING opp_id (path param). */
+data object CrmContactRolesDest {
+    const val ARG_OPP_ID = ContactRolesViewModel.ARG_OPP_ID
+    const val ROUTE = "crm/opportunities/{$ARG_OPP_ID}/contacts"
+
+    fun build(oppId: String): String = "crm/opportunities/" + Uri.encode(oppId) + "/contacts"
+}
+
+/** CRM-AND-OPP — the admin sales-quota view/set route (server admin-gated via 403). */
+data object CrmQuotaDest {
+    const val ROUTE = "crm/quotas"
 }
 
 /** CRM-AND-LED — the marketing prospect pool route. */
@@ -108,7 +144,43 @@ fun NavGraphBuilder.crmDestinations(navController: NavHostController) {
         LeadDetailRoute(onBack = { navController.popBackStack() })
     }
     composable(CrmPipelineDest.ROUTE) {
-        PipelineRoute(onBack = { navController.popBackStack() })
+        PipelineRoute(
+            onBack = { navController.popBackStack() },
+            onOpenForecast = { navController.navigate(CrmForecastDest.build("")) { launchSingleTop = true } },
+            onOpenReport = { navController.navigate(CrmPipelineReportDest.build(admin = false)) { launchSingleTop = true } },
+            onOpenTeamReport = { navController.navigate(CrmPipelineReportDest.build(admin = true)) { launchSingleTop = true } },
+            onOpenQuotas = { navController.navigate(CrmQuotaDest.ROUTE) { launchSingleTop = true } },
+            onOpenContactRoles = { oppId ->
+                navController.navigate(CrmContactRolesDest.build(oppId)) { launchSingleTop = true }
+            },
+        )
+    }
+    composable(
+        route = CrmForecastDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmForecastDest.ARG_PERIOD_KEY) { type = NavType.StringType },
+        ),
+    ) {
+        ForecastRoute(onBack = { navController.popBackStack() })
+    }
+    composable(
+        route = CrmPipelineReportDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmPipelineReportDest.ARG_ADMIN) { type = NavType.StringType },
+        ),
+    ) {
+        PipelineReportRoute(onBack = { navController.popBackStack() })
+    }
+    composable(
+        route = CrmContactRolesDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmContactRolesDest.ARG_OPP_ID) { type = NavType.StringType },
+        ),
+    ) {
+        ContactRolesRoute(onBack = { navController.popBackStack() })
+    }
+    composable(CrmQuotaDest.ROUTE) {
+        QuotaRoute(onBack = { navController.popBackStack() })
     }
     composable(CrmProspectsDest.ROUTE) {
         ProspectPoolRoute(onBack = { navController.popBackStack() })

--- a/android/app/src/test/java/com/testlogon/android/data/crm/ForecastMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/crm/ForecastMathTest.kt
@@ -1,0 +1,160 @@
+package com.testlogon.android.data.crm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * CRM-AND-OPP — JVM unit tests for the pure forecast / quota / pipeline-report maths. No Android types;
+ * degrade-on-bad-input (negative / zero-quota) is asserted so the UI never crashes on a 404 or drift.
+ */
+class ForecastMathTest {
+
+    private data class Row(
+        override val stage: String?,
+        override val count: Int,
+        override val totalAmountCents: Long,
+        override val weightedAmountCents: Long,
+    ) : ForecastMath.StageMetricLike
+
+    // ── attainmentPct ────────────────────────────────────────────────────────
+
+    @Test
+    fun attainment_basicPercent() {
+        assertEquals(50, ForecastMath.attainmentPct(5_000, 10_000))
+        assertEquals(100, ForecastMath.attainmentPct(10_000, 10_000))
+    }
+
+    @Test
+    fun attainment_roundsHalfUp() {
+        // 3333 / 10000 = 33.33% -> 33
+        assertEquals(33, ForecastMath.attainmentPct(3_333, 10_000))
+        // 3335 / 10000 = 33.35 -> 33
+        assertEquals(33, ForecastMath.attainmentPct(3_335, 10_000))
+        // 3355 / 10000 = 33.55 -> 34
+        assertEquals(34, ForecastMath.attainmentPct(3_355, 10_000))
+    }
+
+    @Test
+    fun attainment_canExceed100() {
+        assertEquals(150, ForecastMath.attainmentPct(15_000, 10_000))
+    }
+
+    @Test
+    fun attainment_zeroQuotaDegradesToZero() {
+        assertEquals(0, ForecastMath.attainmentPct(5_000, 0))
+        assertEquals(0, ForecastMath.attainmentPct(5_000, -100))
+    }
+
+    @Test
+    fun attainment_negativeClosedDegradesToZero() {
+        assertEquals(0, ForecastMath.attainmentPct(-5_000, 10_000))
+    }
+
+    // ── gapToQuota ─────────────────────────────────────────────────────────
+
+    @Test
+    fun gap_remainingToQuota() {
+        assertEquals(4_000L, ForecastMath.gapToQuotaCents(6_000, 10_000))
+    }
+
+    @Test
+    fun gap_zeroOnceMet() {
+        assertEquals(0L, ForecastMath.gapToQuotaCents(10_000, 10_000))
+        assertEquals(0L, ForecastMath.gapToQuotaCents(12_000, 10_000))
+    }
+
+    @Test
+    fun gap_zeroQuotaDegradesToZero() {
+        assertEquals(0L, ForecastMath.gapToQuotaCents(5_000, 0))
+    }
+
+    // ── pipelineCoverage ───────────────────────────────────────────────────
+
+    @Test
+    fun coverage_multipleOfGap() {
+        // gap 10k, pipeline 30k -> 300%
+        assertEquals(300, ForecastMath.pipelineCoveragePct(30_000, 0, 10_000))
+    }
+
+    @Test
+    fun coverage_zeroGapDegradesToZero() {
+        // quota already met -> no gap -> 0
+        assertEquals(0, ForecastMath.pipelineCoveragePct(30_000, 10_000, 10_000))
+    }
+
+    // ── rollup ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun rollup_derivedTotals() {
+        val r = ForecastMath.rollup(
+            committedCents = 4_000,
+            bestCaseCents = 8_000,
+            pipelineCents = 20_000,
+            closedCents = 3_000,
+            quotaCents = 10_000,
+        )
+        assertEquals(7_000L, r.commitTotalCents)
+        assertEquals(11_000L, r.bestCaseTotalCents)
+        assertEquals(30, r.attainmentPct)       // 3000/10000
+        assertEquals(7_000L, r.gapToQuotaCents) // 10000-3000
+        assertFalse(r.committedMeetsQuota)      // commitTotal 7000 < 10000
+    }
+
+    @Test
+    fun rollup_committedMeetsQuota() {
+        val r = ForecastMath.rollup(8_000, 9_000, 5_000, 3_000, 10_000)
+        // commitTotal = 3000 + 8000 = 11000 >= 10000
+        assertTrue(r.committedMeetsQuota)
+    }
+
+    @Test
+    fun rollup_clampsNegativeInputs() {
+        val r = ForecastMath.rollup(-1, -1, -1, -1, -1)
+        assertEquals(0L, r.committedCents)
+        assertEquals(0L, r.closedCents)
+        assertEquals(0L, r.quotaCents)
+        assertEquals(0, r.attainmentPct)
+    }
+
+    // ── pipeline-report roll-ups ─────────────────────────────────────────────
+
+    private fun sampleRows() = listOf(
+        Row("prospecting", 3, 30_000, 3_000),
+        Row("negotiation_review", 2, 20_000, 16_000),
+        Row("closed_won", 1, 50_000, 50_000),
+        Row("closed_lost", 4, 40_000, 0),
+    )
+
+    @Test
+    fun report_openTotalsExcludeClosed() {
+        val rows = sampleRows()
+        assertEquals(50_000L, ForecastMath.openTotalAmountCents(rows))    // 30k + 20k
+        assertEquals(19_000L, ForecastMath.openWeightedAmountCents(rows)) // 3k + 16k
+    }
+
+    @Test
+    fun report_wonAmount() {
+        assertEquals(50_000L, ForecastMath.wonAmountCents(sampleRows()))
+    }
+
+    @Test
+    fun report_openCount() {
+        assertEquals(5, ForecastMath.openCount(sampleRows())) // 3 + 2
+    }
+
+    @Test
+    fun report_stageSharePct() {
+        assertEquals(30, ForecastMath.stageSharePct(3, 10))
+        assertEquals(0, ForecastMath.stageSharePct(3, 0)) // divide-by-zero degrade
+    }
+
+    @Test
+    fun report_emptyRowsDegradeToZero() {
+        val empty = emptyList<Row>()
+        assertEquals(0L, ForecastMath.openTotalAmountCents(empty))
+        assertEquals(0L, ForecastMath.wonAmountCents(empty))
+        assertEquals(0, ForecastMath.openCount(empty))
+    }
+}


### PR DESCRIPTION
## FE sweep SWP-140b - Android CRM opportunities depth

Deepens the Android CRM opportunities experience with weighted pipeline forecasting, quota attainment, sales-ops reporting, and richer opportunity/contact surfacing.

### Changes
- `ForecastMath` weighted-pipeline forecast + quota attainment (with unit tests)
- Sales-ops reporting screens (`SalesOpsScreens`) and pipeline screen depth
- New CRM DTOs/models/repository/API paths + navigation wiring
- All new surfaces gated behind the existing CRM feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
