### PR TITLE
FE sweep SWP-141a - Android CRM projects depth (tasks/members/templates)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
@@ -5,6 +5,7 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -46,6 +47,146 @@ interface CrmProjectsApi {
         @Query("cursor") cursor: String? = null,
         @Query("limit") limit: Int? = null,
     ): CrmProjectTaskListRespDto
+
+    // ── PRJ-002: project update / delete ──────────────────────────────────────
+
+    @PATCH("v1/crm/projects/{projectId}")
+    suspend fun updateProject(
+        @Path("projectId") projectId: String,
+        @Body body: CrmProjectUpdateInDto,
+    ): CrmProjectDto
+
+    // 200 with an {ok:true}-ish body; a bare Unit tolerates any shape.
+    @DELETE("v1/crm/projects/{projectId}")
+    suspend fun deleteProject(@Path("projectId") projectId: String)
+
+    // ── PRJ-003/004/005: task board + workload + milestones ───────────────────
+
+    @POST("v1/crm/projects/{projectId}/tasks")
+    suspend fun createTask(
+        @Path("projectId") projectId: String,
+        @Body body: CrmProjectTaskCreateInDto,
+    ): CrmProjectTaskDto
+
+    @GET("v1/crm/projects/{projectId}/tasks/{taskId}")
+    suspend fun getTask(
+        @Path("projectId") projectId: String,
+        @Path("taskId") taskId: String,
+    ): CrmProjectTaskDto
+
+    @PATCH("v1/crm/projects/{projectId}/tasks/{taskId}")
+    suspend fun updateTask(
+        @Path("projectId") projectId: String,
+        @Path("taskId") taskId: String,
+        @Body body: CrmProjectTaskUpdateInDto,
+    ): CrmProjectTaskDto
+
+    @DELETE("v1/crm/projects/{projectId}/tasks/{taskId}")
+    suspend fun deleteTask(
+        @Path("projectId") projectId: String,
+        @Path("taskId") taskId: String,
+    )
+
+    @PUT("v1/crm/projects/{projectId}/tasks/order")
+    suspend fun reorderTasks(
+        @Path("projectId") projectId: String,
+        @Body body: CrmProjectTaskReorderInDto,
+    ): CrmProjectTaskOrderRespDto
+
+    @GET("v1/crm/projects/{projectId}/workload")
+    suspend fun getWorkload(@Path("projectId") projectId: String): CrmProjectWorkloadRespDto
+
+    @GET("v1/crm/projects/{projectId}/milestones")
+    suspend fun getMilestoneSummary(
+        @Path("projectId") projectId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmMilestoneSummaryRespDto
+
+    @GET("v1/crm/projects/{projectId}/status-history")
+    suspend fun getStatusHistory(
+        @Path("projectId") projectId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmProjectStatusHistoryRespDto
+
+    // ── PRJ-007: members ──────────────────────────────────────────────────────
+
+    @POST("v1/crm/projects/{projectId}/members")
+    suspend fun addMember(
+        @Path("projectId") projectId: String,
+        @Body body: CrmProjectAddMemberInDto,
+    ): CrmProjectMemberDto
+
+    @GET("v1/crm/projects/{projectId}/members")
+    suspend fun listMembers(
+        @Path("projectId") projectId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmProjectMemberListRespDto
+
+    @PATCH("v1/crm/projects/{projectId}/members/{userSub}")
+    suspend fun updateMemberRole(
+        @Path("projectId") projectId: String,
+        @Path("userSub") userSub: String,
+        @Body body: CrmProjectUpdateMemberInDto,
+    ): CrmProjectMemberDto
+
+    @DELETE("v1/crm/projects/{projectId}/members/{userSub}")
+    suspend fun removeMember(
+        @Path("projectId") projectId: String,
+        @Path("userSub") userSub: String,
+    )
+
+    // ── PRJ-010: contact links ────────────────────────────────────────────────
+
+    @POST("v1/crm/projects/{projectId}/contact-links")
+    suspend fun addContactLink(
+        @Path("projectId") projectId: String,
+        @Body body: CrmProjectAddContactLinkInDto,
+    ): CrmProjectContactLinkDto
+
+    @GET("v1/crm/projects/{projectId}/contact-links")
+    suspend fun listContactLinks(
+        @Path("projectId") projectId: String,
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmProjectContactLinkListRespDto
+
+    @DELETE("v1/crm/projects/{projectId}/contact-links/{entityId}")
+    suspend fun removeContactLink(
+        @Path("projectId") projectId: String,
+        @Path("entityId") entityId: String,
+    )
+
+    // ── PRJ-006: templates (owner-scoped; degrade-on-404) ─────────────────────
+
+    @GET("v1/crm/projects/templates")
+    suspend fun listTemplates(
+        @Query("cursor") cursor: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): CrmTemplateListRespDto
+
+    @GET("v1/crm/projects/templates/{templateId}")
+    suspend fun getTemplate(@Path("templateId") templateId: String): CrmProjectTemplateDto
+
+    @POST("v1/crm/projects/templates")
+    suspend fun createTemplate(@Body body: CrmTemplateCreateInDto): CrmProjectTemplateDto
+
+    @POST("v1/crm/projects/templates/from-project/{projectId}")
+    suspend fun createTemplateFromProject(
+        @Path("projectId") projectId: String,
+        @Body body: CrmTemplateFromProjectInDto,
+    ): CrmProjectTemplateDto
+
+    @DELETE("v1/crm/projects/templates/{templateId}")
+    suspend fun deleteTemplate(@Path("templateId") templateId: String)
+
+    @POST("v1/crm/projects/templates/{templateId}/instantiate")
+    suspend fun instantiateTemplate(
+        @Path("templateId") templateId: String,
+        @Body body: CrmTemplateInstantiateInDto,
+    ): CrmProjectDto
 }
 
 // ─── Events: prefix /ui/crm/events ───────────────────────────────────────────

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
@@ -61,6 +61,9 @@ data class CrmProjectTaskDto(
     @Json(name = "percent_complete") val percentComplete: Int = 0,
     @Json(name = "is_milestone") val isMilestone: Boolean = false,
     @Json(name = "assigned_user_sub") val assignedUserSub: String? = null,
+    @Json(name = "predecessor_task_ids") val predecessorTaskIds: List<String> = emptyList(),
+    @Json(name = "project_resource_type") val projectResourceType: String = "user",
+    @Json(name = "linked_contact_id") val linkedContactId: String? = null,
     @Json(name = "created_at") val createdAt: Long = 0,
     @Json(name = "updated_at") val updatedAt: Long = 0,
 )
@@ -212,4 +215,221 @@ data class CrmCampaignAttributionDto(
     @Json(name = "open_rate") val openRate: Double = 0.0,
     @Json(name = "click_count") val clickCount: Int = 0,
     @Json(name = "click_rate") val clickRate: Double = 0.0,
+)
+
+// ───────────────────────  PROJECTS: PRJ-002+ additions  ───────────────────────
+// PRJ-002/003/004/005/006/007/009/010 — task board, workload, milestones, templates,
+// members, status history, contact links. Mirrors frontend/src/api/endpoints/crmProjects.ts.
+
+// Partial project update (PATCH). Only set fields are sent; nulls are omitted by Moshi.
+@JsonClass(generateAdapter = true)
+data class CrmProjectUpdateInDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "status") val status: String? = null,
+    @Json(name = "priority") val priority: Int? = null,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "assigned_user_sub") val assignedUserSub: String? = null,
+    @Json(name = "account_id") val accountId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTaskCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "task_order") val taskOrder: Int? = null,
+    @Json(name = "duration_days") val durationDays: Int? = null,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "percent_complete") val percentComplete: Int? = null,
+    @Json(name = "is_milestone") val isMilestone: Boolean? = null,
+    @Json(name = "assigned_user_sub") val assignedUserSub: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTaskUpdateInDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "task_order") val taskOrder: Int? = null,
+    @Json(name = "duration_days") val durationDays: Int? = null,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "percent_complete") val percentComplete: Int? = null,
+    @Json(name = "is_milestone") val isMilestone: Boolean? = null,
+    @Json(name = "assigned_user_sub") val assignedUserSub: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTaskReorderInDto(
+    @Json(name = "task_ids") val taskIds: List<String>,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTaskOrderRespDto(
+    @Json(name = "items") val items: List<CrmProjectTaskDto> = emptyList(),
+)
+
+// ── Workload (PRJ-004) ─────────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmTaskWorkloadEntryDto(
+    @Json(name = "assignee_key") val assigneeKey: String = "",
+    @Json(name = "resource_type") val resourceType: String = "user",
+    @Json(name = "assigned_id") val assignedId: String = "",
+    @Json(name = "task_count") val taskCount: Int = 0,
+    @Json(name = "overdue_count") val overdueCount: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectWorkloadRespDto(
+    @Json(name = "project_id") val projectId: String = "",
+    @Json(name = "entries") val entries: List<CrmTaskWorkloadEntryDto> = emptyList(),
+)
+
+// ── Milestones (PRJ-005) ───────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmMilestoneSummaryItemDto(
+    @Json(name = "id") val id: String = "",
+    @Json(name = "project_id") val projectId: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "task_order") val taskOrder: Int = 0,
+    @Json(name = "start_date") val startDate: Long? = null,
+    @Json(name = "end_date") val endDate: Long? = null,
+    @Json(name = "percent_complete") val percentComplete: Int = 0,
+    @Json(name = "on_track") val onTrack: Boolean = false,
+    @Json(name = "overdue") val overdue: Boolean = false,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmMilestoneSummaryRespDto(
+    @Json(name = "items") val items: List<CrmMilestoneSummaryItemDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+    @Json(name = "total_milestones") val totalMilestones: Int = 0,
+    @Json(name = "overdue_count") val overdueCount: Int = 0,
+    @Json(name = "on_track_count") val onTrackCount: Int = 0,
+    @Json(name = "no_date_count") val noDateCount: Int = 0,
+)
+
+// ── Templates (PRJ-006) ────────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmTemplateTaskDefDto(
+    @Json(name = "template_task_id") val templateTaskId: String = "",
+    @Json(name = "name") val name: String = "",
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "task_order") val taskOrder: Int = 0,
+    @Json(name = "duration_days") val durationDays: Int = 1,
+    @Json(name = "is_milestone") val isMilestone: Boolean = false,
+    @Json(name = "predecessor_template_task_ids") val predecessorTemplateTaskIds: List<String> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectTemplateDto(
+    @Json(name = "id") val id: String = "",
+    @Json(name = "owner_sub") val ownerSub: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "task_defs") val taskDefs: List<CrmTemplateTaskDefDto> = emptyList(),
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmTemplateListRespDto(
+    @Json(name = "items") val items: List<CrmProjectTemplateDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmTemplateCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String? = null,
+    @Json(name = "task_defs") val taskDefs: List<CrmTemplateTaskDefDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmTemplateFromProjectInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "description") val description: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmTemplateInstantiateInDto(
+    @Json(name = "project_name") val projectName: String,
+    @Json(name = "start_date") val startDate: Long? = null,
+)
+
+// ── Members (PRJ-007) ──────────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectMemberDto(
+    @Json(name = "project_id") val projectId: String = "",
+    @Json(name = "user_sub") val userSub: String = "",
+    @Json(name = "role") val role: String = "member",
+    @Json(name = "added_by") val addedBy: String = "",
+    @Json(name = "added_at") val addedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectMemberListRespDto(
+    @Json(name = "items") val items: List<CrmProjectMemberDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectAddMemberInDto(
+    @Json(name = "user_sub") val userSub: String,
+    @Json(name = "role") val role: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectUpdateMemberInDto(
+    @Json(name = "role") val role: String,
+)
+
+// ── Status history (PRJ-009) ───────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectStatusHistoryEntryDto(
+    @Json(name = "project_id") val projectId: String = "",
+    @Json(name = "from_status") val fromStatus: String? = null,
+    @Json(name = "to_status") val toStatus: String = "",
+    @Json(name = "changed_by") val changedBy: String = "",
+    @Json(name = "changed_at") val changedAt: Long = 0,
+    @Json(name = "event_id") val eventId: String = "",
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectStatusHistoryRespDto(
+    @Json(name = "items") val items: List<CrmProjectStatusHistoryEntryDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+// ── Contact links (PRJ-010) ────────────────────────────────────────────────
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectContactLinkDto(
+    @Json(name = "project_id") val projectId: String = "",
+    @Json(name = "linked_entity_id") val linkedEntityId: String = "",
+    @Json(name = "linked_entity_type") val linkedEntityType: String = "",
+    @Json(name = "added_by") val addedBy: String = "",
+    @Json(name = "added_at") val addedAt: Long = 0,
+    @Json(name = "note") val note: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectContactLinkListRespDto(
+    @Json(name = "items") val items: List<CrmProjectContactLinkDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmProjectAddContactLinkInDto(
+    @Json(name = "linked_entity_id") val linkedEntityId: String,
+    @Json(name = "linked_entity_type") val linkedEntityType: String? = null,
+    @Json(name = "note") val note: String? = null,
 )

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
@@ -31,6 +31,8 @@ data class CrmProjectTask(
     val endDate: Long?,
     val percentComplete: Int,
     val isMilestone: Boolean,
+    val assignedUserSub: String? = null,
+    val predecessorTaskIds: List<String> = emptyList(),
 )
 
 // ─── Events ──────────────────────────────────────────────────────────────────
@@ -133,6 +135,8 @@ fun CrmProjectTaskDto.toDomain(): CrmProjectTask = CrmProjectTask(
     endDate = endDate,
     percentComplete = percentComplete,
     isMilestone = isMilestone,
+    assignedUserSub = assignedUserSub,
+    predecessorTaskIds = predecessorTaskIds,
 )
 
 fun CrmEventDto.toDomain(): CrmEvent = CrmEvent(
@@ -201,4 +205,161 @@ fun CrmCampaignAttributionDto.toDomain(): CrmCampaignAttribution = CrmCampaignAt
     openRate = openRate,
     clickCount = clickCount,
     clickRate = clickRate,
+)
+
+// ───────────────────────  PROJECTS: PRJ-002+ domain + mappers  ─────────────────
+// PRJ-002/003/004/005/006/007/009/010 domain models. Raw DTOs never leak to the UI.
+
+data class CrmProjectMember(
+    val projectId: String,
+    val userSub: String,
+    val role: String,
+    val addedBy: String,
+    val addedAt: Long,
+)
+
+data class CrmTaskWorkloadEntry(
+    val assigneeKey: String,
+    val resourceType: String,
+    val assignedId: String,
+    val taskCount: Int,
+    val overdueCount: Int,
+)
+
+data class CrmProjectWorkload(
+    val projectId: String,
+    val entries: List<CrmTaskWorkloadEntry>,
+)
+
+data class CrmMilestoneSummaryItem(
+    val id: String,
+    val name: String,
+    val taskOrder: Int,
+    val startDate: Long?,
+    val endDate: Long?,
+    val percentComplete: Int,
+    val onTrack: Boolean,
+    val overdue: Boolean,
+)
+
+data class CrmMilestoneSummary(
+    val items: List<CrmMilestoneSummaryItem>,
+    val totalMilestones: Int,
+    val overdueCount: Int,
+    val onTrackCount: Int,
+    val noDateCount: Int,
+)
+
+data class CrmTemplateTaskDef(
+    val templateTaskId: String,
+    val name: String,
+    val description: String?,
+    val taskOrder: Int,
+    val durationDays: Int,
+    val isMilestone: Boolean,
+)
+
+data class CrmProjectTemplate(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val taskDefs: List<CrmTemplateTaskDef>,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class CrmProjectStatusHistoryEntry(
+    val projectId: String,
+    val fromStatus: String?,
+    val toStatus: String,
+    val changedBy: String,
+    val changedAt: Long,
+    val eventId: String,
+)
+
+data class CrmProjectContactLink(
+    val projectId: String,
+    val linkedEntityId: String,
+    val linkedEntityType: String,
+    val addedBy: String,
+    val addedAt: Long,
+    val note: String?,
+)
+
+// ── Mappers ─────────────────────────────────────────────────────────────────
+
+fun CrmProjectMemberDto.toDomain(): CrmProjectMember = CrmProjectMember(
+    projectId = projectId,
+    userSub = userSub,
+    role = role,
+    addedBy = addedBy,
+    addedAt = addedAt,
+)
+
+fun CrmTaskWorkloadEntryDto.toDomain(): CrmTaskWorkloadEntry = CrmTaskWorkloadEntry(
+    assigneeKey = assigneeKey,
+    resourceType = resourceType,
+    assignedId = assignedId,
+    taskCount = taskCount,
+    overdueCount = overdueCount,
+)
+
+fun CrmProjectWorkloadRespDto.toDomain(): CrmProjectWorkload = CrmProjectWorkload(
+    projectId = projectId,
+    entries = entries.map { it.toDomain() },
+)
+
+fun CrmMilestoneSummaryItemDto.toDomain(): CrmMilestoneSummaryItem = CrmMilestoneSummaryItem(
+    id = id,
+    name = name,
+    taskOrder = taskOrder,
+    startDate = startDate,
+    endDate = endDate,
+    percentComplete = percentComplete,
+    onTrack = onTrack,
+    overdue = overdue,
+)
+
+fun CrmMilestoneSummaryRespDto.toDomain(): CrmMilestoneSummary = CrmMilestoneSummary(
+    items = items.map { it.toDomain() },
+    totalMilestones = totalMilestones,
+    overdueCount = overdueCount,
+    onTrackCount = onTrackCount,
+    noDateCount = noDateCount,
+)
+
+fun CrmTemplateTaskDefDto.toDomain(): CrmTemplateTaskDef = CrmTemplateTaskDef(
+    templateTaskId = templateTaskId,
+    name = name,
+    description = description,
+    taskOrder = taskOrder,
+    durationDays = durationDays,
+    isMilestone = isMilestone,
+)
+
+fun CrmProjectTemplateDto.toDomain(): CrmProjectTemplate = CrmProjectTemplate(
+    id = id,
+    name = name,
+    description = description,
+    taskDefs = taskDefs.map { it.toDomain() },
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun CrmProjectStatusHistoryEntryDto.toDomain(): CrmProjectStatusHistoryEntry = CrmProjectStatusHistoryEntry(
+    projectId = projectId,
+    fromStatus = fromStatus,
+    toStatus = toStatus,
+    changedBy = changedBy,
+    changedAt = changedAt,
+    eventId = eventId,
+)
+
+fun CrmProjectContactLinkDto.toDomain(): CrmProjectContactLink = CrmProjectContactLink(
+    projectId = projectId,
+    linkedEntityId = linkedEntityId,
+    linkedEntityType = linkedEntityType,
+    addedBy = addedBy,
+    addedAt = addedAt,
+    note = note,
 )

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
@@ -23,6 +23,9 @@ data class CrmProjectsPage(
 data class CrmProjectDetail(
     val project: CrmProject,
     val tasks: List<CrmProjectTask>,
+    val members: List<CrmProjectMember> = emptyList(),
+    val milestones: CrmMilestoneSummary? = null,
+    val workload: CrmProjectWorkload? = null,
 )
 
 data class CrmEventsPage(
@@ -54,12 +57,53 @@ data class CrmCampaignDetail(
     val attribution: CrmCampaignAttribution?,
 )
 
+data class CrmTemplatesResult(
+    val templates: List<CrmProjectTemplate>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
 // ───────────────────────────  PROJECTS  ──────────────────────────────
 
 interface CrmProjectsRepository {
     suspend fun list(status: String? = null): ApiResult<CrmProjectsPage>
     suspend fun detail(projectId: String): ApiResult<CrmProjectDetail>
     suspend fun create(body: CrmProjectCreateInDto): ApiResult<CrmProject>
+
+    // PRJ-002: project update / delete
+    suspend fun update(projectId: String, body: CrmProjectUpdateInDto): ApiResult<CrmProject>
+    suspend fun delete(projectId: String): ApiResult<Unit>
+
+    // PRJ-003: tasks
+    suspend fun createTask(projectId: String, body: CrmProjectTaskCreateInDto): ApiResult<CrmProjectTask>
+    suspend fun getTask(projectId: String, taskId: String): ApiResult<CrmProjectTask>
+    suspend fun updateTask(projectId: String, taskId: String, body: CrmProjectTaskUpdateInDto): ApiResult<CrmProjectTask>
+    suspend fun deleteTask(projectId: String, taskId: String): ApiResult<Unit>
+    suspend fun reorderTasks(projectId: String, taskIds: List<String>): ApiResult<List<CrmProjectTask>>
+
+    // PRJ-004/005/009: workload / milestones / status history
+    suspend fun workload(projectId: String): ApiResult<CrmProjectWorkload?>
+    suspend fun milestoneSummary(projectId: String): ApiResult<CrmMilestoneSummary?>
+    suspend fun statusHistory(projectId: String): ApiResult<List<CrmProjectStatusHistoryEntry>>
+
+    // PRJ-007: members
+    suspend fun listMembers(projectId: String): ApiResult<List<CrmProjectMember>>
+    suspend fun addMember(projectId: String, userSub: String, role: String?): ApiResult<CrmProjectMember>
+    suspend fun updateMemberRole(projectId: String, userSub: String, role: String): ApiResult<CrmProjectMember>
+    suspend fun removeMember(projectId: String, userSub: String): ApiResult<Unit>
+
+    // PRJ-010: contact links
+    suspend fun listContactLinks(projectId: String): ApiResult<List<CrmProjectContactLink>>
+    suspend fun addContactLink(projectId: String, entityId: String, entityType: String?, note: String?): ApiResult<CrmProjectContactLink>
+    suspend fun removeContactLink(projectId: String, entityId: String): ApiResult<Unit>
+
+    // PRJ-006: templates
+    suspend fun listTemplates(): ApiResult<CrmTemplatesResult>
+    suspend fun getTemplate(templateId: String): ApiResult<CrmProjectTemplate>
+    suspend fun createTemplate(name: String, description: String?): ApiResult<CrmProjectTemplate>
+    suspend fun createTemplateFromProject(projectId: String, name: String, description: String?): ApiResult<CrmProjectTemplate>
+    suspend fun deleteTemplate(templateId: String): ApiResult<Unit>
+    suspend fun instantiateTemplate(templateId: String, projectName: String, startDate: Long?): ApiResult<CrmProject>
 }
 
 @Singleton
@@ -85,10 +129,17 @@ class CrmProjectsRepositoryImpl @Inject constructor(
     override suspend fun detail(projectId: String): ApiResult<CrmProjectDetail> = withContext(io) {
         when (val proj = call { api.getProject(projectId).toDomain() }) {
             is ApiResult.Success -> {
-                // Tasks are best-effort; a failure/degradation renders an empty task list.
+                // Tasks / members / milestones / workload are best-effort; a failure or a
+                // degraded (404) sub-resource renders an empty slice rather than failing the page.
                 val tasks = (call { api.listTasks(projectId) } as? ApiResult.Success)
                     ?.data?.items?.map { it.toDomain() }?.sortedBy { it.taskOrder } ?: emptyList()
-                ApiResult.Success(CrmProjectDetail(proj.data, tasks))
+                val members = (call { api.listMembers(projectId) } as? ApiResult.Success)
+                    ?.data?.items?.map { it.toDomain() } ?: emptyList()
+                val milestones = (call { api.getMilestoneSummary(projectId) } as? ApiResult.Success)
+                    ?.data?.toDomain()
+                val workload = (call { api.getWorkload(projectId) } as? ApiResult.Success)
+                    ?.data?.toDomain()
+                ApiResult.Success(CrmProjectDetail(proj.data, tasks, members, milestones, workload))
             }
             is ApiResult.Failure -> proj
             is ApiResult.NetworkError -> proj
@@ -97,6 +148,176 @@ class CrmProjectsRepositoryImpl @Inject constructor(
 
     override suspend fun create(body: CrmProjectCreateInDto): ApiResult<CrmProject> = withContext(io) {
         call { api.createProject(body).toDomain() }
+    }
+
+    override suspend fun update(projectId: String, body: CrmProjectUpdateInDto): ApiResult<CrmProject> =
+        withContext(io) { call { api.updateProject(projectId, body).toDomain() } }
+
+    override suspend fun delete(projectId: String): ApiResult<Unit> = withContext(io) {
+        call { api.deleteProject(projectId) }
+    }
+
+    override suspend fun createTask(
+        projectId: String,
+        body: CrmProjectTaskCreateInDto,
+    ): ApiResult<CrmProjectTask> = withContext(io) {
+        call { api.createTask(projectId, body).toDomain() }
+    }
+
+    override suspend fun getTask(projectId: String, taskId: String): ApiResult<CrmProjectTask> =
+        withContext(io) { call { api.getTask(projectId, taskId).toDomain() } }
+
+    override suspend fun updateTask(
+        projectId: String,
+        taskId: String,
+        body: CrmProjectTaskUpdateInDto,
+    ): ApiResult<CrmProjectTask> = withContext(io) {
+        call { api.updateTask(projectId, taskId, body).toDomain() }
+    }
+
+    override suspend fun deleteTask(projectId: String, taskId: String): ApiResult<Unit> =
+        withContext(io) { call { api.deleteTask(projectId, taskId) } }
+
+    override suspend fun reorderTasks(
+        projectId: String,
+        taskIds: List<String>,
+    ): ApiResult<List<CrmProjectTask>> = withContext(io) {
+        when (val res = call { api.reorderTasks(projectId, CrmProjectTaskReorderInDto(taskIds)) }) {
+            is ApiResult.Success -> ApiResult.Success(res.data.items.map { it.toDomain() })
+            is ApiResult.Failure -> res
+            is ApiResult.NetworkError -> res
+        }
+    }
+
+    override suspend fun workload(projectId: String): ApiResult<CrmProjectWorkload?> = withContext(io) {
+        when (val res = call { api.getWorkload(projectId).toDomain() }) {
+            is ApiResult.Success -> res
+            is ApiResult.Failure -> if (res.error.status == 404) ApiResult.Success(null) else res
+            is ApiResult.NetworkError -> res
+        }
+    }
+
+    override suspend fun milestoneSummary(projectId: String): ApiResult<CrmMilestoneSummary?> = withContext(io) {
+        when (val res = call { api.getMilestoneSummary(projectId).toDomain() }) {
+            is ApiResult.Success -> res
+            is ApiResult.Failure -> if (res.error.status == 404) ApiResult.Success(null) else res
+            is ApiResult.NetworkError -> res
+        }
+    }
+
+    override suspend fun statusHistory(projectId: String): ApiResult<List<CrmProjectStatusHistoryEntry>> =
+        withContext(io) {
+            when (val res = call { api.getStatusHistory(projectId) }) {
+                is ApiResult.Success -> ApiResult.Success(res.data.items.map { it.toDomain() })
+                is ApiResult.Failure -> if (res.error.status == 404) ApiResult.Success(emptyList()) else res
+                is ApiResult.NetworkError -> res
+            }
+        }
+
+    override suspend fun listMembers(projectId: String): ApiResult<List<CrmProjectMember>> = withContext(io) {
+        when (val res = call { api.listMembers(projectId) }) {
+            is ApiResult.Success -> ApiResult.Success(res.data.items.map { it.toDomain() })
+            is ApiResult.Failure -> if (res.error.status == 404) ApiResult.Success(emptyList()) else res
+            is ApiResult.NetworkError -> res
+        }
+    }
+
+    override suspend fun addMember(
+        projectId: String,
+        userSub: String,
+        role: String?,
+    ): ApiResult<CrmProjectMember> = withContext(io) {
+        call { api.addMember(projectId, CrmProjectAddMemberInDto(userSub = userSub, role = role?.ifBlank { null })).toDomain() }
+    }
+
+    override suspend fun updateMemberRole(
+        projectId: String,
+        userSub: String,
+        role: String,
+    ): ApiResult<CrmProjectMember> = withContext(io) {
+        call { api.updateMemberRole(projectId, userSub, CrmProjectUpdateMemberInDto(role = role)).toDomain() }
+    }
+
+    override suspend fun removeMember(projectId: String, userSub: String): ApiResult<Unit> =
+        withContext(io) { call { api.removeMember(projectId, userSub) } }
+
+    override suspend fun listContactLinks(projectId: String): ApiResult<List<CrmProjectContactLink>> =
+        withContext(io) {
+            when (val res = call { api.listContactLinks(projectId) }) {
+                is ApiResult.Success -> ApiResult.Success(res.data.items.map { it.toDomain() })
+                is ApiResult.Failure -> if (res.error.status == 404) ApiResult.Success(emptyList()) else res
+                is ApiResult.NetworkError -> res
+            }
+        }
+
+    override suspend fun addContactLink(
+        projectId: String,
+        entityId: String,
+        entityType: String?,
+        note: String?,
+    ): ApiResult<CrmProjectContactLink> = withContext(io) {
+        call {
+            api.addContactLink(
+                projectId,
+                CrmProjectAddContactLinkInDto(
+                    linkedEntityId = entityId,
+                    linkedEntityType = entityType?.ifBlank { null },
+                    note = note?.ifBlank { null },
+                ),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun removeContactLink(projectId: String, entityId: String): ApiResult<Unit> =
+        withContext(io) { call { api.removeContactLink(projectId, entityId) } }
+
+    override suspend fun listTemplates(): ApiResult<CrmTemplatesResult> = withContext(io) {
+        when (val res = call { api.listTemplates() }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmTemplatesResult(res.data.items.map { it.toDomain() }, res.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (res.error.status == 404) ApiResult.Success(CrmTemplatesResult(emptyList(), null, moduleDisabled = true))
+                else res
+            is ApiResult.NetworkError -> res
+        }
+    }
+
+    override suspend fun getTemplate(templateId: String): ApiResult<CrmProjectTemplate> =
+        withContext(io) { call { api.getTemplate(templateId).toDomain() } }
+
+    override suspend fun createTemplate(name: String, description: String?): ApiResult<CrmProjectTemplate> =
+        withContext(io) {
+            call { api.createTemplate(CrmTemplateCreateInDto(name = name, description = description?.ifBlank { null })).toDomain() }
+        }
+
+    override suspend fun createTemplateFromProject(
+        projectId: String,
+        name: String,
+        description: String?,
+    ): ApiResult<CrmProjectTemplate> = withContext(io) {
+        call {
+            api.createTemplateFromProject(
+                projectId,
+                CrmTemplateFromProjectInDto(name = name, description = description?.ifBlank { null }),
+            ).toDomain()
+        }
+    }
+
+    override suspend fun deleteTemplate(templateId: String): ApiResult<Unit> =
+        withContext(io) { call { api.deleteTemplate(templateId) } }
+
+    override suspend fun instantiateTemplate(
+        templateId: String,
+        projectName: String,
+        startDate: Long?,
+    ): ApiResult<CrmProject> = withContext(io) {
+        call {
+            api.instantiateTemplate(
+                templateId,
+                CrmTemplateInstantiateInDto(projectName = projectName, startDate = startDate),
+            ).toDomain()
+        }
     }
 
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/ProjectMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/ProjectMath.kt
@@ -1,0 +1,205 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CRM-AND-PRJ — PURE, framework-free logic for the SuiteCRM Projects task-board / milestones /
+ * workload / members surfaces. No Android / java.time types leak in, so every function is
+ * JVM-unit-testable (mirrors the CrmPecMath / CrmSalesMath idiom).
+ *
+ * Mirrors the LIVE web contract (frontend/src/api/endpoints/crmProjects.ts) + the backend
+ * (app/routers/crm_projects.py + app/models.py CrmProjectTask* / CrmMilestone* / CrmTaskWorkload*
+ * / CrmProjectMember*).
+ *
+ * Responsibilities:
+ *  - task ordering + a client-side reorder (move up / move down / drag) that yields the ordered
+ *    id list the PUT /tasks/order route expects.
+ *  - milestone summary roll-up (total / overdue / on-track / no-date counts) derived client-side so
+ *    the board still shows sane numbers when GET /milestones degrades (404).
+ *  - workload aggregation (per-assignee task + overdue counts) derived from a task list when GET
+ *    /workload degrades.
+ *  - member-role ordering + labels (mirror CrmProjectMemberRole).
+ *
+ * Degrade, never throw: null / malformed inputs render neutrally rather than raising.
+ */
+object ProjectMath {
+
+    const val EM_DASH: String = "—"
+
+    // ── Task order / reorder ──────────────────────────────────────────────────
+
+    /**
+     * Stable sort of tasks by their [CrmProjectTask.taskOrder], breaking ties by name so the board
+     * is deterministic even when the server hands back duplicate orders (dev-host drift).
+     */
+    fun sortedByOrder(tasks: List<CrmProjectTask>): List<CrmProjectTask> =
+        tasks.sortedWith(compareBy({ it.taskOrder }, { it.name }))
+
+    /**
+     * Move the task at [index] one slot toward the front (up). Returns the new ordered id list to
+     * send to PUT /tasks/order. Out-of-range / first-position is a no-op (returns the current ids).
+     */
+    fun moveUp(tasks: List<CrmProjectTask>, index: Int): List<String> {
+        val ids = sortedByOrder(tasks).map { it.id }.toMutableList()
+        if (index <= 0 || index >= ids.size) return ids
+        val tmp = ids[index - 1]
+        ids[index - 1] = ids[index]
+        ids[index] = tmp
+        return ids
+    }
+
+    /**
+     * Move the task at [index] one slot toward the back (down). Out-of-range / last-position is a
+     * no-op (returns the current ids).
+     */
+    fun moveDown(tasks: List<CrmProjectTask>, index: Int): List<String> {
+        val ids = sortedByOrder(tasks).map { it.id }.toMutableList()
+        if (index < 0 || index >= ids.size - 1) return ids
+        val tmp = ids[index + 1]
+        ids[index + 1] = ids[index]
+        ids[index] = tmp
+        return ids
+    }
+
+    /**
+     * The next task_order to hand a freshly-created task so it lands at the end of the board. Mirrors
+     * the backend's "0 = auto-assign" convention by returning (max existing order + 1), or 0 for an
+     * empty project.
+     */
+    fun nextTaskOrder(tasks: List<CrmProjectTask>): Int =
+        if (tasks.isEmpty()) 0 else (tasks.maxOf { it.taskOrder } + 1)
+
+    // ── Milestones ────────────────────────────────────────────────────────────
+
+    /** A task is a milestone when the server flag is set. */
+    fun milestones(tasks: List<CrmProjectTask>): List<CrmProjectTask> =
+        sortedByOrder(tasks.filter { it.isMilestone })
+
+    /**
+     * Overdue = a not-yet-complete task whose end_date is in the past (relative to [nowSeconds]).
+     * Tolerant of epoch-millis end dates (magnitude ≥ 1e12 is divided down). A null / non-positive
+     * end date is never overdue (no date to miss).
+     */
+    fun isOverdue(task: CrmProjectTask, nowSeconds: Long): Boolean {
+        if (task.percentComplete >= 100) return false
+        val end = task.endDate ?: return false
+        if (end <= 0) return false
+        val endSec = if (end >= 1_000_000_000_000L) end / 1000 else end
+        return endSec < nowSeconds
+    }
+
+    /** On track = a milestone that is neither complete nor overdue and has a target end date. */
+    fun isOnTrack(task: CrmProjectTask, nowSeconds: Long): Boolean {
+        if (task.percentComplete >= 100) return true
+        val end = task.endDate ?: return false
+        if (end <= 0) return false
+        return !isOverdue(task, nowSeconds)
+    }
+
+    /**
+     * Client-side milestone roll-up used when GET /milestones degrades (404) — mirrors
+     * CrmMilestoneSummaryResp's counts. `noDate` milestones have no end date (can't be judged).
+     */
+    data class MilestoneSummary(
+        val total: Int,
+        val overdue: Int,
+        val onTrack: Int,
+        val noDate: Int,
+    )
+
+    fun milestoneSummary(tasks: List<CrmProjectTask>, nowSeconds: Long): MilestoneSummary {
+        val ms = milestones(tasks)
+        var overdue = 0
+        var onTrack = 0
+        var noDate = 0
+        for (m in ms) {
+            val end = m.endDate
+            when {
+                end == null || end <= 0 -> noDate++
+                isOverdue(m, nowSeconds) -> overdue++
+                else -> onTrack++
+            }
+        }
+        return MilestoneSummary(total = ms.size, overdue = overdue, onTrack = onTrack, noDate = noDate)
+    }
+
+    // ── Workload ──────────────────────────────────────────────────────────────
+
+    /** Per-assignee workload row derived from a task list (mirrors CrmTaskWorkloadEntry). */
+    data class WorkloadRow(
+        val assigneeKey: String,
+        val taskCount: Int,
+        val overdueCount: Int,
+    )
+
+    private const val UNASSIGNED_KEY = "unassigned"
+
+    /**
+     * Aggregate a task list into per-assignee workload rows, sorted by task count (desc) then key.
+     * Tasks with no assignee roll up under an "unassigned" bucket. Used when GET /workload degrades.
+     */
+    fun workload(tasks: List<CrmProjectTask>, nowSeconds: Long): List<WorkloadRow> {
+        val counts = LinkedHashMap<String, IntArray>() // key -> [total, overdue]
+        for (t in tasks) {
+            val key = t.assignedUserSub?.takeIf { it.isNotBlank() } ?: UNASSIGNED_KEY
+            val row = counts.getOrPut(key) { intArrayOf(0, 0) }
+            row[0] += 1
+            if (isOverdue(t, nowSeconds)) row[1] += 1
+        }
+        return counts.entries
+            .map { WorkloadRow(it.key, it.value[0], it.value[1]) }
+            .sortedWith(compareByDescending<WorkloadRow> { it.taskCount }.thenBy { it.assigneeKey })
+    }
+
+    /** Display label for a workload assignee key (the "unassigned" bucket gets a friendly name). */
+    fun assigneeLabel(key: String?): String = when {
+        key.isNullOrBlank() -> "Unassigned"
+        key == UNASSIGNED_KEY -> "Unassigned"
+        else -> key
+    }
+
+    // ── Member roles ──────────────────────────────────────────────────────────
+
+    const val ROLE_OWNER = "owner"
+    const val ROLE_MEMBER = "member"
+    const val ROLE_VIEWER = "viewer"
+
+    /** Ordered, curated role list for the add/edit chip row (mirror CrmProjectMemberRole). */
+    val MEMBER_ROLES: List<String> = listOf(ROLE_OWNER, ROLE_MEMBER, ROLE_VIEWER)
+
+    fun memberRoleLabel(role: String?): String = when (role) {
+        ROLE_OWNER -> "Owner"
+        ROLE_MEMBER -> "Member"
+        ROLE_VIEWER -> "Viewer"
+        null -> EM_DASH
+        else -> titleCaseSnake(role)
+    }
+
+    /** Sort members owner → member → viewer, then by user sub, so the roster is stable. */
+    fun sortedMembers(members: List<CrmProjectMember>): List<CrmProjectMember> {
+        val rank = mapOf(ROLE_OWNER to 0, ROLE_MEMBER to 1, ROLE_VIEWER to 2)
+        return members.sortedWith(
+            compareBy({ rank[it.role] ?: 99 }, { it.userSub }),
+        )
+    }
+
+    // ── Templates ─────────────────────────────────────────────────────────────
+
+    /** Count of milestone task-defs in a template (surfaced on the template picker row). */
+    fun templateMilestoneCount(def: CrmProjectTemplate): Int =
+        def.taskDefs.count { it.isMilestone }
+
+    /** Short "N tasks · M milestones" label for a template row. */
+    fun templateSummaryLabel(def: CrmProjectTemplate): String {
+        val tasks = def.taskDefs.size
+        val ms = templateMilestoneCount(def)
+        val tPart = if (tasks == 1) "1 task" else "$tasks tasks"
+        return if (ms > 0) "$tPart · $ms milestone${if (ms == 1) "" else "s"}" else tPart
+    }
+
+    // ── internal ──────────────────────────────────────────────────────────────
+
+    private fun titleCaseSnake(raw: String): String =
+        raw.split('_', ' ')
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { part -> part.replaceFirstChar { c -> c.uppercaseChar() } }
+            .ifBlank { EM_DASH }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsScreens.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsScreens.kt
@@ -18,6 +18,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
@@ -52,8 +55,11 @@ import com.testlogon.android.core.ui.state.ErrorState
 import com.testlogon.android.core.ui.state.LoadingState
 import com.testlogon.android.core.ui.state.OfflineBanner
 import com.testlogon.android.data.crm.CrmProject
+import com.testlogon.android.data.crm.CrmProjectMember
 import com.testlogon.android.data.crm.CrmProjectTask
+import com.testlogon.android.data.crm.CrmProjectTemplate
 import com.testlogon.android.data.crm.CrmPecMath
+import com.testlogon.android.data.crm.ProjectMath
 
 object CrmProjectsTestTags {
     const val SCREEN = "crm_projects_screen"
@@ -62,6 +68,8 @@ object CrmProjectsTestTags {
     const val ERROR = "crm_projects_error"
     const val FAB = "crm_projects_fab"
     const val DETAIL = "crm_project_detail"
+    const val TEMPLATES = "crm_projects_templates"
+    const val TASK_FAB = "crm_project_task_fab"
 }
 
 // ─── List ─────────────────────────────────────────────────────────────────────
@@ -82,6 +90,10 @@ fun CrmProjectsRoute(
         onRetry = viewModel::onRetry,
         onCreate = viewModel::createProject,
         onClearCreateError = viewModel::clearCreateError,
+        onLoadTemplates = viewModel::loadTemplates,
+        onInstantiateTemplate = viewModel::instantiateTemplate,
+        onDeleteTemplate = viewModel::deleteTemplate,
+        onClearTemplateError = viewModel::clearTemplateError,
         modifier = modifier,
     )
 }
@@ -95,9 +107,14 @@ fun CrmProjectsScreen(
     onRetry: () -> Unit,
     onCreate: (String, String?, String?, (String) -> Unit) -> Unit,
     onClearCreateError: () -> Unit,
+    onLoadTemplates: () -> Unit,
+    onInstantiateTemplate: (String, String, (String) -> Unit) -> Unit,
+    onDeleteTemplate: (String) -> Unit,
+    onClearTemplateError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showCreate by remember { mutableStateOf(false) }
+    var showTemplates by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier.testTag(CrmProjectsTestTags.SCREEN),
@@ -108,6 +125,15 @@ fun CrmProjectsScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    TextButton(
+                        onClick = {
+                            showTemplates = true
+                            onLoadTemplates()
+                        },
+                        modifier = Modifier.testTag(CrmProjectsTestTags.TEMPLATES),
+                    ) { Text("Templates") }
                 },
             )
         },
@@ -170,6 +196,23 @@ fun CrmProjectsScreen(
             },
         )
     }
+
+    if (showTemplates) {
+        TemplatesSheet(
+            state = state,
+            onDismiss = {
+                showTemplates = false
+                onClearTemplateError()
+            },
+            onInstantiate = { templateId, projectName ->
+                onInstantiateTemplate(templateId, projectName) { id ->
+                    showTemplates = false
+                    onProjectClick(id)
+                }
+            },
+            onDelete = onDeleteTemplate,
+        )
+    }
 }
 
 @Composable
@@ -201,7 +244,22 @@ fun CrmProjectDetailRoute(
     viewModel: CrmProjectDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    CrmProjectDetailScreen(state = state, onBack = onBack, onRetry = viewModel::onRetry, modifier = modifier)
+    CrmProjectDetailScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::onRetry,
+        onCreateTask = viewModel::createTask,
+        onSetTaskProgress = viewModel::setTaskProgress,
+        onToggleMilestone = viewModel::toggleMilestone,
+        onDeleteTask = viewModel::deleteTask,
+        onMoveTaskUp = viewModel::moveTaskUp,
+        onMoveTaskDown = viewModel::moveTaskDown,
+        onAddMember = viewModel::addMember,
+        onUpdateMemberRole = viewModel::updateMemberRole,
+        onRemoveMember = viewModel::removeMember,
+        onClearActionError = viewModel::clearActionError,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -209,8 +267,21 @@ fun CrmProjectDetailScreen(
     state: CrmProjectDetailUiState,
     onBack: () -> Unit,
     onRetry: () -> Unit,
+    onCreateTask: (String, Boolean, String?) -> Unit,
+    onSetTaskProgress: (String, Int) -> Unit,
+    onToggleMilestone: (String, Boolean) -> Unit,
+    onDeleteTask: (String) -> Unit,
+    onMoveTaskUp: (Int) -> Unit,
+    onMoveTaskDown: (Int) -> Unit,
+    onAddMember: (String, String) -> Unit,
+    onUpdateMemberRole: (String, String) -> Unit,
+    onRemoveMember: (String) -> Unit,
+    onClearActionError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var showAddTask by remember { mutableStateOf(false) }
+    var showAddMember by remember { mutableStateOf(false) }
+
     Scaffold(
         modifier = modifier.testTag(CrmProjectsTestTags.DETAIL),
         topBar = {
@@ -222,6 +293,14 @@ fun CrmProjectDetailScreen(
                     }
                 },
             )
+        },
+        floatingActionButton = {
+            if (state.phase == CrmProjectDetailUiState.Phase.Content) {
+                FloatingActionButton(
+                    onClick = { showAddTask = true },
+                    modifier = Modifier.testTag(CrmProjectsTestTags.TASK_FAB),
+                ) { Icon(Icons.Filled.Add, contentDescription = "New task") }
+            }
         },
     ) { padding ->
         when (state.phase) {
@@ -238,6 +317,7 @@ fun CrmProjectDetailScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.actionError != null) InfoBanner(state.actionError)
                     if (project != null) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             AssistChip(onClick = {}, label = { Text(CrmPecMath.projectStatusLabel(project.status)) })
@@ -248,30 +328,219 @@ fun CrmProjectDetailScreen(
                             LabeledValue("Description", project.description)
                         }
                     }
+
+                    // ── Milestones summary ──────────────────────────────────────
+                    MilestonesSection(state)
+
+                    // ── Workload ────────────────────────────────────────────────
+                    WorkloadSection(state)
+
+                    // ── Tasks board ─────────────────────────────────────────────
                     Text("Tasks", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                     if (state.tasks.isEmpty()) {
-                        Text("No tasks.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("No tasks. Tap + to add one.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     } else {
-                        state.tasks.forEach { TaskRow(it) }
+                        state.tasks.forEachIndexed { index, task ->
+                            TaskRow(
+                                task = task,
+                                index = index,
+                                total = state.tasks.size,
+                                busy = state.actionBusy,
+                                onSetProgress = { pct -> onSetTaskProgress(task.id, pct) },
+                                onToggleMilestone = { onToggleMilestone(task.id, !task.isMilestone) },
+                                onDelete = { onDeleteTask(task.id) },
+                                onMoveUp = { onMoveTaskUp(index) },
+                                onMoveDown = { onMoveTaskDown(index) },
+                            )
+                        }
+                    }
+
+                    // ── Members ─────────────────────────────────────────────────
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text("Members", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        TextButton(onClick = { showAddMember = true }) { Text("Add") }
+                    }
+                    if (state.members.isEmpty()) {
+                        Text("No members yet.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    } else {
+                        state.members.forEach { member ->
+                            MemberRow(
+                                member = member,
+                                busy = state.actionBusy,
+                                onSetRole = { role -> onUpdateMemberRole(member.userSub, role) },
+                                onRemove = { onRemoveMember(member.userSub) },
+                            )
+                        }
                     }
                 }
+            }
+        }
+    }
+
+    if (showAddTask) {
+        AddTaskSheet(
+            busy = state.actionBusy,
+            error = state.actionError,
+            onDismiss = {
+                showAddTask = false
+                onClearActionError()
+            },
+            onSubmit = { name, isMilestone, assignee ->
+                onCreateTask(name, isMilestone, assignee)
+                showAddTask = false
+            },
+        )
+    }
+
+    if (showAddMember) {
+        AddMemberSheet(
+            busy = state.actionBusy,
+            error = state.actionError,
+            onDismiss = {
+                showAddMember = false
+                onClearActionError()
+            },
+            onSubmit = { userSub, role ->
+                onAddMember(userSub, role)
+                showAddMember = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun MilestonesSection(state: CrmProjectDetailUiState) {
+    // Prefer the server summary; fall back to a client-derived roll-up (degrade-on-404).
+    val server = state.milestones
+    val derived = ProjectMath.milestoneSummary(state.tasks, System.currentTimeMillis() / 1000)
+    val total = server?.totalMilestones ?: derived.total
+    if (total == 0) return
+    val overdue = server?.overdueCount ?: derived.overdue
+    val onTrack = server?.onTrackCount ?: derived.onTrack
+    val noDate = server?.noDateCount ?: derived.noDate
+    Text("Milestones", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+    Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        AssistChip(onClick = {}, label = { Text("$total total") })
+        AssistChip(onClick = {}, label = { Text("$onTrack on track") })
+        AssistChip(onClick = {}, label = { Text("$overdue overdue") })
+        if (noDate > 0) AssistChip(onClick = {}, label = { Text("$noDate no date") })
+    }
+}
+
+@Composable
+private fun WorkloadSection(state: CrmProjectDetailUiState) {
+    // Prefer the server workload entries; fall back to a client-derived aggregation.
+    val serverEntries = state.workload?.entries
+    val rows = if (!serverEntries.isNullOrEmpty()) {
+        serverEntries.map { Triple(it.assigneeKey, it.taskCount, it.overdueCount) }
+    } else {
+        ProjectMath.workload(state.tasks, System.currentTimeMillis() / 1000)
+            .map { Triple(it.assigneeKey, it.taskCount, it.overdueCount) }
+    }
+    if (rows.isEmpty()) return
+    Text("Workload", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+    rows.forEach { (key, count, overdue) ->
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(ProjectMath.assigneeLabel(key), style = MaterialTheme.typography.bodyMedium)
+            Text(
+                if (overdue > 0) "$count tasks · $overdue overdue" else "$count tasks",
+                style = MaterialTheme.typography.bodySmall,
+                color = if (overdue > 0) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TaskRow(
+    task: CrmProjectTask,
+    index: Int,
+    total: Int,
+    busy: Boolean,
+    onSetProgress: (Int) -> Unit,
+    onToggleMilestone: () -> Unit,
+    onDelete: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    (if (task.isMilestone) "◆ " else "") + task.name.ifBlank { "(untitled task)" },
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onMoveUp, enabled = !busy && index > 0) {
+                    Icon(Icons.Filled.KeyboardArrowUp, contentDescription = "Move up")
+                }
+                IconButton(onClick = onMoveDown, enabled = !busy && index < total - 1) {
+                    Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "Move down")
+                }
+                IconButton(onClick = onDelete, enabled = !busy) {
+                    Icon(Icons.Filled.Delete, contentDescription = "Delete task")
+                }
+            }
+            val pct = CrmPecMath.clampPercent(task.percentComplete)
+            LinearProgressIndicator(progress = { pct / 100f }, modifier = Modifier.fillMaxWidth())
+            Text("$pct% · ${CrmPecMath.dateRange(task.startDate, task.endDate)}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                listOf(0, 25, 50, 75, 100).forEach { p ->
+                    FilterChip(selected = pct == p, enabled = !busy, onClick = { onSetProgress(p) }, label = { Text("$p%") })
+                }
+                FilterChip(
+                    selected = task.isMilestone,
+                    enabled = !busy,
+                    onClick = onToggleMilestone,
+                    label = { Text("Milestone") },
+                )
             }
         }
     }
 }
 
 @Composable
-private fun TaskRow(task: CrmProjectTask) {
+private fun MemberRow(
+    member: CrmProjectMember,
+    busy: Boolean,
+    onSetRole: (String) -> Unit,
+    onRemove: () -> Unit,
+) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
-                (if (task.isMilestone) "◆ " else "") + task.name.ifBlank { "(untitled task)" },
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-            )
-            val pct = CrmPecMath.clampPercent(task.percentComplete)
-            LinearProgressIndicator(progress = { pct / 100f }, modifier = Modifier.fillMaxWidth())
-            Text("$pct% · ${CrmPecMath.dateRange(task.startDate, task.endDate)}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(member.userSub, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+                IconButton(onClick = onRemove, enabled = !busy) {
+                    Icon(Icons.Filled.Delete, contentDescription = "Remove member")
+                }
+            }
+            Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                ProjectMath.MEMBER_ROLES.forEach { role ->
+                    FilterChip(
+                        selected = member.role == role,
+                        enabled = !busy,
+                        onClick = { if (member.role != role) onSetRole(role) },
+                        label = { Text(ProjectMath.memberRoleLabel(role)) },
+                    )
+                }
+            }
         }
     }
 }
@@ -284,7 +553,7 @@ internal fun LabeledValue(label: String, value: String) {
     }
 }
 
-// ─── Create sheet ───────────────────────────────────────────────────────────
+// ─── Create project sheet ─────────────────────────────────────────────────────
 
 @Composable
 private fun CreateProjectSheet(
@@ -331,5 +600,156 @@ private fun CreateProjectSheet(
             }
         },
         dismissButton = { TextButton(enabled = !submitting, onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+// ─── Add task sheet ───────────────────────────────────────────────────────────
+
+@Composable
+private fun AddTaskSheet(
+    busy: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (name: String, isMilestone: Boolean, assignee: String?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var assignee by remember { mutableStateOf("") }
+    var isMilestone by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if (!busy) onDismiss() },
+        title = { Text("New task") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(name, { name = it }, label = { Text("Task name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(assignee, { assignee = it }, label = { Text("Assignee sub (optional)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                FilterChip(selected = isMilestone, onClick = { isMilestone = !isMilestone }, label = { Text("Milestone") })
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !busy, onClick = { onSubmit(name, isMilestone, assignee) }) {
+                if (busy) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Add")
+            }
+        },
+        dismissButton = { TextButton(enabled = !busy, onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+// ─── Add member sheet ─────────────────────────────────────────────────────────
+
+@Composable
+private fun AddMemberSheet(
+    busy: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onSubmit: (userSub: String, role: String) -> Unit,
+) {
+    var userSub by remember { mutableStateOf("") }
+    var role by remember { mutableStateOf(ProjectMath.ROLE_MEMBER) }
+
+    AlertDialog(
+        onDismissRequest = { if (!busy) onDismiss() },
+        title = { Text("Add member") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(userSub, { userSub = it }, label = { Text("User sub") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                Text("Role", style = MaterialTheme.typography.labelMedium)
+                Row(
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    ProjectMath.MEMBER_ROLES.forEach { rr ->
+                        FilterChip(selected = rr == role, onClick = { role = rr }, label = { Text(ProjectMath.memberRoleLabel(rr)) })
+                    }
+                }
+                if (error != null) {
+                    Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = !busy, onClick = { onSubmit(userSub, role) }) {
+                if (busy) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Add")
+            }
+        },
+        dismissButton = { TextButton(enabled = !busy, onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+// ─── Templates sheet ──────────────────────────────────────────────────────────
+
+@Composable
+private fun TemplatesSheet(
+    state: CrmProjectsUiState,
+    onDismiss: () -> Unit,
+    onInstantiate: (templateId: String, projectName: String) -> Unit,
+    onDelete: (String) -> Unit,
+) {
+    var selected by remember { mutableStateOf<CrmProjectTemplate?>(null) }
+    var projectName by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Project templates") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                when {
+                    state.templatesLoading -> CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    state.templatesModuleDisabled -> Text("Templates are not enabled for this account.", style = MaterialTheme.typography.bodyMedium)
+                    state.templates.isEmpty() -> Text("No templates yet.", style = MaterialTheme.typography.bodyMedium)
+                    else -> state.templates.forEach { t ->
+                        val isSel = selected?.id == t.id
+                        Card(
+                            modifier = Modifier.fillMaxWidth().clickable {
+                                selected = if (isSel) null else t
+                                if (!isSel && projectName.isBlank()) projectName = t.name
+                            },
+                        ) {
+                            Column(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(t.name.ifBlank { "(untitled)" }, style = MaterialTheme.typography.bodyLarge, fontWeight = if (isSel) FontWeight.Bold else FontWeight.Medium)
+                                    IconButton(onClick = { onDelete(t.id) }, enabled = !state.templateActionBusy) {
+                                        Icon(Icons.Filled.Delete, contentDescription = "Delete template")
+                                    }
+                                }
+                                Text(ProjectMath.templateSummaryLabel(t), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                        }
+                    }
+                }
+                if (selected != null) {
+                    OutlinedTextField(projectName, { projectName = it }, label = { Text("New project name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                }
+                if (state.templateError != null) {
+                    Text(state.templateError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            val sel = selected
+            TextButton(
+                enabled = sel != null && !state.templateActionBusy && projectName.isNotBlank(),
+                onClick = { if (sel != null) onInstantiate(sel.id, projectName) },
+            ) {
+                if (state.templateActionBusy) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Create project")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
     )
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsViewModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmProjectsViewModels.kt
@@ -4,10 +4,17 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmMilestoneSummary
 import com.testlogon.android.data.crm.CrmProject
 import com.testlogon.android.data.crm.CrmProjectCreateInDto
+import com.testlogon.android.data.crm.CrmProjectMember
 import com.testlogon.android.data.crm.CrmProjectTask
+import com.testlogon.android.data.crm.CrmProjectTaskCreateInDto
+import com.testlogon.android.data.crm.CrmProjectTaskUpdateInDto
+import com.testlogon.android.data.crm.CrmProjectTemplate
+import com.testlogon.android.data.crm.CrmProjectWorkload
 import com.testlogon.android.data.crm.CrmProjectsRepository
+import com.testlogon.android.data.crm.ProjectMath
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +34,12 @@ data class CrmProjectsUiState(
     val errorMessage: String? = null,
     val createSubmitting: Boolean = false,
     val createError: String? = null,
+    // PRJ-006 templates
+    val templates: List<CrmProjectTemplate> = emptyList(),
+    val templatesLoading: Boolean = false,
+    val templatesModuleDisabled: Boolean = false,
+    val templateActionBusy: Boolean = false,
+    val templateError: String? = null,
 ) {
     enum class Phase { Loading, Content, Error }
 }
@@ -124,6 +137,60 @@ class CrmProjectsViewModel @Inject constructor(
     }
 
     fun clearCreateError() = _uiState.update { it.copy(createError = null) }
+
+    // ── PRJ-006 templates ─────────────────────────────────────────────────────
+
+    fun loadTemplates() {
+        _uiState.update { it.copy(templatesLoading = true, templateError = null) }
+        viewModelScope.launch {
+            when (val res = repository.listTemplates()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        templatesLoading = false,
+                        templates = res.data.templates,
+                        templatesModuleDisabled = res.data.moduleDisabled,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(templatesLoading = false, templateError = res.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(templatesLoading = false, templateError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun instantiateTemplate(templateId: String, projectName: String, onCreated: (String) -> Unit) {
+        if (projectName.isBlank()) {
+            _uiState.update { it.copy(templateError = "A project name is required.") }
+            return
+        }
+        _uiState.update { it.copy(templateActionBusy = true, templateError = null) }
+        viewModelScope.launch {
+            when (val res = repository.instantiateTemplate(templateId, projectName.trim(), startDate = null)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(templateActionBusy = false) }
+                    onCreated(res.data.id)
+                    load(fromUser = false)
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(templateActionBusy = false, templateError = res.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(templateActionBusy = false, templateError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun deleteTemplate(templateId: String) {
+        _uiState.update { it.copy(templateActionBusy = true, templateError = null) }
+        viewModelScope.launch {
+            when (val res = repository.deleteTemplate(templateId)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(templateActionBusy = false) }
+                    loadTemplates()
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(templateActionBusy = false, templateError = res.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(templateActionBusy = false, templateError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun clearTemplateError() = _uiState.update { it.copy(templateError = null) }
 }
 
 // ─── Project detail ───────────────────────────────────────────────────────────
@@ -132,8 +199,13 @@ data class CrmProjectDetailUiState(
     val phase: Phase = Phase.Loading,
     val project: CrmProject? = null,
     val tasks: List<CrmProjectTask> = emptyList(),
+    val members: List<CrmProjectMember> = emptyList(),
+    val milestones: CrmMilestoneSummary? = null,
+    val workload: CrmProjectWorkload? = null,
     val isOffline: Boolean = false,
     val errorMessage: String? = null,
+    val actionBusy: Boolean = false,
+    val actionError: String? = null,
 ) {
     enum class Phase { Loading, Content, Error }
 }
@@ -167,7 +239,10 @@ class CrmProjectDetailViewModel @Inject constructor(
                     it.copy(
                         phase = CrmProjectDetailUiState.Phase.Content,
                         project = r.data.project,
-                        tasks = r.data.tasks,
+                        tasks = ProjectMath.sortedByOrder(r.data.tasks),
+                        members = ProjectMath.sortedMembers(r.data.members),
+                        milestones = r.data.milestones,
+                        workload = r.data.workload,
                         isOffline = false,
                         errorMessage = null,
                     )
@@ -186,6 +261,80 @@ class CrmProjectDetailViewModel @Inject constructor(
                         errorMessage = "You're offline. Try again.",
                     )
                 }
+            }
+        }
+    }
+
+    // ── PRJ-003 task actions ───────────────────────────────────────────────────
+
+    fun createTask(name: String, isMilestone: Boolean, assignee: String?) {
+        if (name.isBlank()) {
+            _uiState.update { it.copy(actionError = "A task name is required.") }
+            return
+        }
+        runAction {
+            repository.createTask(
+                projectId,
+                CrmProjectTaskCreateInDto(
+                    name = name.trim(),
+                    taskOrder = ProjectMath.nextTaskOrder(_uiState.value.tasks),
+                    isMilestone = isMilestone,
+                    assignedUserSub = assignee?.trim()?.ifBlank { null },
+                ),
+            )
+        }
+    }
+
+    fun setTaskProgress(taskId: String, percentComplete: Int) = runAction {
+        repository.updateTask(
+            projectId, taskId,
+            CrmProjectTaskUpdateInDto(percentComplete = percentComplete.coerceIn(0, 100)),
+        )
+    }
+
+    fun toggleMilestone(taskId: String, isMilestone: Boolean) = runAction {
+        repository.updateTask(projectId, taskId, CrmProjectTaskUpdateInDto(isMilestone = isMilestone))
+    }
+
+    fun deleteTask(taskId: String) = runAction { repository.deleteTask(projectId, taskId) }
+
+    fun moveTaskUp(index: Int) = runAction {
+        repository.reorderTasks(projectId, ProjectMath.moveUp(_uiState.value.tasks, index))
+    }
+
+    fun moveTaskDown(index: Int) = runAction {
+        repository.reorderTasks(projectId, ProjectMath.moveDown(_uiState.value.tasks, index))
+    }
+
+    // ── PRJ-007 member actions ─────────────────────────────────────────────────
+
+    fun addMember(userSub: String, role: String) {
+        if (userSub.isBlank()) {
+            _uiState.update { it.copy(actionError = "A user is required.") }
+            return
+        }
+        runAction { repository.addMember(projectId, userSub.trim(), role) }
+    }
+
+    fun updateMemberRole(userSub: String, role: String) = runAction {
+        repository.updateMemberRole(projectId, userSub, role)
+    }
+
+    fun removeMember(userSub: String) = runAction { repository.removeMember(projectId, userSub) }
+
+    fun clearActionError() = _uiState.update { it.copy(actionError = null) }
+
+    /** Runs a mutating repo call, then reloads the detail so every slice stays consistent. */
+    private fun runAction(block: suspend () -> ApiResult<*>) {
+        _uiState.update { it.copy(actionBusy = true, actionError = null) }
+        viewModelScope.launch {
+            when (val res = block()) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(actionBusy = false) }
+                    load()
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(actionBusy = false, actionError = res.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(actionBusy = false, actionError = "You're offline. Try again.") }
             }
         }
     }

--- a/android/app/src/test/java/com/testlogon/android/data/crm/ProjectMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/crm/ProjectMathTest.kt
@@ -1,0 +1,186 @@
+package com.testlogon.android.data.crm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * CRM-AND-PRJ — JVM unit tests for the pure Projects task-board / milestone / workload / member
+ * logic. No Android types; degrade-on-bad-input is asserted so the UI never crashes on a 404
+ * (module disabled) or dev-host drift.
+ */
+class ProjectMathTest {
+
+    private fun task(
+        id: String,
+        order: Int = 0,
+        name: String = id,
+        pct: Int = 0,
+        end: Long? = null,
+        milestone: Boolean = false,
+        assignee: String? = null,
+    ) = CrmProjectTask(
+        id = id,
+        name = name,
+        description = null,
+        taskOrder = order,
+        durationDays = 1,
+        startDate = null,
+        endDate = end,
+        percentComplete = pct,
+        isMilestone = milestone,
+        assignedUserSub = assignee,
+        predecessorTaskIds = emptyList(),
+    )
+
+    // ── Ordering / reorder ────────────────────────────────────────────────────
+
+    @Test
+    fun sortedByOrder_ordersByTaskOrderThenName() {
+        // order 1 ties broken by name: "a" (name="a") < "c" (name="zzz"); then order 2 "b".
+        val out = ProjectMath.sortedByOrder(
+            listOf(task("b", order = 2), task("a", order = 1), task("c", order = 1, name = "zzz")),
+        )
+        assertEquals(listOf("a", "c", "b"), out.map { it.id })
+    }
+
+    @Test
+    fun moveUp_swapsWithPrevious() {
+        val tasks = listOf(task("a", 0), task("b", 1), task("c", 2))
+        assertEquals(listOf("a", "c", "b"), ProjectMath.moveUp(tasks, 2))
+    }
+
+    @Test
+    fun moveUp_firstPositionIsNoOp() {
+        val tasks = listOf(task("a", 0), task("b", 1))
+        assertEquals(listOf("a", "b"), ProjectMath.moveUp(tasks, 0))
+    }
+
+    @Test
+    fun moveDown_swapsWithNext() {
+        val tasks = listOf(task("a", 0), task("b", 1), task("c", 2))
+        assertEquals(listOf("b", "a", "c"), ProjectMath.moveDown(tasks, 0))
+    }
+
+    @Test
+    fun moveDown_lastPositionIsNoOp() {
+        val tasks = listOf(task("a", 0), task("b", 1))
+        assertEquals(listOf("a", "b"), ProjectMath.moveDown(tasks, 1))
+    }
+
+    @Test
+    fun nextTaskOrder_emptyAndPopulated() {
+        assertEquals(0, ProjectMath.nextTaskOrder(emptyList()))
+        assertEquals(6, ProjectMath.nextTaskOrder(listOf(task("a", 5), task("b", 2))))
+    }
+
+    // ── Overdue / on-track ────────────────────────────────────────────────────
+
+    @Test
+    fun isOverdue_pastEndAndIncomplete() {
+        val now = 1_000_000L
+        assertTrue(ProjectMath.isOverdue(task("a", end = 900_000L, pct = 40), now))
+        // complete -> never overdue
+        assertFalse(ProjectMath.isOverdue(task("a", end = 900_000L, pct = 100), now))
+        // future end -> not overdue
+        assertFalse(ProjectMath.isOverdue(task("a", end = 1_100_000L, pct = 0), now))
+        // no date -> not overdue
+        assertFalse(ProjectMath.isOverdue(task("a", end = null, pct = 0), now))
+    }
+
+    @Test
+    fun isOverdue_toleratesEpochMillis() {
+        // now = 1_000_000 s; end supplied in millis for the same instant -> not overdue
+        assertFalse(ProjectMath.isOverdue(task("a", end = 1_000_000_000L * 1000, pct = 0), 1_000_000L))
+    }
+
+    // ── Milestone summary ─────────────────────────────────────────────────────
+
+    @Test
+    fun milestoneSummary_countsBuckets() {
+        val now = 1_000_000L
+        val tasks = listOf(
+            task("m1", milestone = true, end = 900_000L, pct = 10),   // overdue
+            task("m2", milestone = true, end = 1_100_000L, pct = 10), // on track
+            task("m3", milestone = true, end = null, pct = 0),        // no date
+            task("m4", milestone = true, end = 900_000L, pct = 100),  // complete -> on track
+            task("t1", milestone = false, end = 900_000L),            // not a milestone
+        )
+        val s = ProjectMath.milestoneSummary(tasks, now)
+        assertEquals(4, s.total)
+        assertEquals(1, s.overdue)
+        assertEquals(2, s.onTrack)
+        assertEquals(1, s.noDate)
+    }
+
+    // ── Workload ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun workload_aggregatesPerAssigneeWithOverdue() {
+        val now = 1_000_000L
+        val rows = ProjectMath.workload(
+            listOf(
+                task("a", assignee = "u1", end = 900_000L, pct = 0),   // u1 overdue
+                task("b", assignee = "u1", end = 1_100_000L, pct = 0), // u1 ok
+                task("c", assignee = "u2", end = 900_000L, pct = 0),   // u2 overdue
+                task("d", assignee = null, end = null),                // unassigned
+            ),
+            now,
+        )
+        // u1 has the most tasks -> first
+        assertEquals("u1", rows[0].assigneeKey)
+        assertEquals(2, rows[0].taskCount)
+        assertEquals(1, rows[0].overdueCount)
+        val unassigned = rows.first { it.assigneeKey == "unassigned" }
+        assertEquals(1, unassigned.taskCount)
+        assertEquals(0, unassigned.overdueCount)
+    }
+
+    @Test
+    fun assigneeLabel_unassignedFriendly() {
+        assertEquals("Unassigned", ProjectMath.assigneeLabel(null))
+        assertEquals("Unassigned", ProjectMath.assigneeLabel("unassigned"))
+        assertEquals("u1", ProjectMath.assigneeLabel("u1"))
+    }
+
+    // ── Member roles ──────────────────────────────────────────────────────────
+
+    @Test
+    fun memberRoleLabel_knownAndUnknown() {
+        assertEquals("Owner", ProjectMath.memberRoleLabel("owner"))
+        assertEquals("Member", ProjectMath.memberRoleLabel("member"))
+        assertEquals("Viewer", ProjectMath.memberRoleLabel("viewer"))
+        assertEquals(ProjectMath.EM_DASH, ProjectMath.memberRoleLabel(null))
+        assertEquals("Co Owner", ProjectMath.memberRoleLabel("co_owner"))
+    }
+
+    @Test
+    fun sortedMembers_ownerFirst() {
+        val members = listOf(
+            CrmProjectMember(projectId = "p", userSub = "v", role = "viewer", addedBy = "x", addedAt = 0),
+            CrmProjectMember(projectId = "p", userSub = "o", role = "owner", addedBy = "x", addedAt = 0),
+            CrmProjectMember(projectId = "p", userSub = "m", role = "member", addedBy = "x", addedAt = 0),
+        )
+        assertEquals(listOf("o", "m", "v"), ProjectMath.sortedMembers(members).map { it.userSub })
+    }
+
+    // ── Templates ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun templateSummary_labelsTasksAndMilestones() {
+        val def = CrmProjectTemplate(
+            id = "t",
+            name = "Launch",
+            description = null,
+            taskDefs = listOf(
+                CrmTemplateTaskDef("1", "kick", null, 0, 1, false),
+                CrmTemplateTaskDef("2", "ms", null, 1, 1, true),
+            ),
+            createdAt = 0,
+            updatedAt = 0,
+        )
+        assertEquals(1, ProjectMath.templateMilestoneCount(def))
+        assertEquals("2 tasks · 1 milestone", ProjectMath.templateSummaryLabel(def))
+    }
+}


### PR DESCRIPTION
## FE sweep SWP-141a - Android CRM projects depth

Deepens the Android CRM projects surface with task lists, member
assignment, and project templates.

### Changes
- PEC API/DTO/model/repository layers extended for tasks, members, and templates
- New `ProjectMath` helper with unit test coverage
- CRM projects screens and view models updated to drive the new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
