### PR TITLE
FE sweep SWP-141c - Android CRM campaigns depth (editor/send/templates/analytics)

### DIFF
--- a/android/app/src/main/java/com/testlogon/android/data/crm/CampaignMath.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CampaignMath.kt
@@ -1,0 +1,188 @@
+package com.testlogon.android.data.crm
+
+/**
+ * CMP — PURE, framework-free logic for the CRM Marketing Campaigns surface (send eligibility,
+ * A/B variant split, HTML email-template merge-var validation). No Android / java.time types
+ * leak in, so every function is JVM-unit-testable (mirrors the CrmPecMath / CrmSalesMath idiom).
+ *
+ * Mirrors the LIVE web contract (crmCampaigns.ts / crmEmail.ts → app/routers/crm_campaigns.py):
+ *  - a campaign is send-eligible only when it targets at least one audience (contact list or
+ *    segment) and is not already in a terminal/sent status.
+ *  - the A/B split apportions a resolved audience across N variants as evenly as possible, giving
+ *    the remainder to the earliest variants (deterministic, sums back to the total).
+ *  - merge-var validation extracts {{ var }} placeholders (same regex as the server's _VAR_RE) and
+ *    reports which are unfilled by a given sample map.
+ *
+ * Degrade, never throw: null / malformed inputs return neutral results rather than raising, so a
+ * 404 (module disabled) or dev-host drift renders cleanly.
+ */
+object CampaignMath {
+
+    // ── Campaign send eligibility ─────────────────────────────────────────────
+
+    /** Statuses in which a campaign can no longer be (re-)sent. Mirrors the server lifecycle. */
+    val TERMINAL_STATUSES: Set<String> = setOf("sent", "sending", "completed", "archived", "cancelled")
+
+    /** A campaign targets an audience when it has at least one contact list or segment. */
+    fun hasAudience(contactListIds: List<String>?, segmentIds: List<String>?): Boolean {
+        val lists = contactListIds?.count { it.isNotBlank() } ?: 0
+        val segs = segmentIds?.count { it.isNotBlank() } ?: 0
+        return lists + segs > 0
+    }
+
+    /** Total distinct-ish audience source count (lists + segments), ignoring blanks. */
+    fun audienceSourceCount(contactListIds: List<String>?, segmentIds: List<String>?): Int {
+        val lists = contactListIds?.count { it.isNotBlank() } ?: 0
+        val segs = segmentIds?.count { it.isNotBlank() } ?: 0
+        return lists + segs
+    }
+
+    /**
+     * Whether a "Send" (or "Send test") action is meaningful. Requires an audience and a
+     * non-terminal status. A blank/unknown status is treated as draft (eligible).
+     */
+    fun canSend(status: String?, contactListIds: List<String>?, segmentIds: List<String>?): Boolean {
+        if (!hasAudience(contactListIds, segmentIds)) return false
+        val s = status?.trim()?.lowercase()
+        if (s.isNullOrBlank()) return true
+        return s !in TERMINAL_STATUSES
+    }
+
+    /** Coarse reason a send is blocked, for surfacing a helper line under the Send button. */
+    fun sendBlockedReason(status: String?, contactListIds: List<String>?, segmentIds: List<String>?): String? {
+        if (!hasAudience(contactListIds, segmentIds)) {
+            return "Add a contact list or segment before sending."
+        }
+        val s = status?.trim()?.lowercase()
+        if (!s.isNullOrBlank() && s in TERMINAL_STATUSES) {
+            return "This campaign has already been sent."
+        }
+        return null
+    }
+
+    // ── A/B split ─────────────────────────────────────────────────────────────
+
+    /**
+     * Apportion [audienceSize] recipients across [variantCount] variants as evenly as possible.
+     * The remainder (audienceSize mod variantCount) is handed to the earliest variants, one each,
+     * so the returned list always sums back to [audienceSize] and is non-increasing.
+     *
+     * Degrades: a non-positive variant count returns an empty split; a non-positive audience
+     * returns all-zeros of length variantCount.
+     */
+    fun abSplit(audienceSize: Int, variantCount: Int): List<Int> {
+        if (variantCount <= 0) return emptyList()
+        if (audienceSize <= 0) return List(variantCount) { 0 }
+        val base = audienceSize / variantCount
+        val remainder = audienceSize % variantCount
+        return List(variantCount) { i -> base + if (i < remainder) 1 else 0 }
+    }
+
+    /**
+     * The percentage share (0..100, one decimal precision as a Double) each variant receives of a
+     * given [variantCount]-way even split. Used for the editor's "50% / 50%" hint. Empty when
+     * variantCount <= 0.
+     */
+    fun abSplitPercents(variantCount: Int): List<Double> {
+        if (variantCount <= 0) return emptyList()
+        val each = 100.0 / variantCount
+        val rounded = kotlin.math.round(each * 10.0) / 10.0
+        return List(variantCount) { rounded }
+    }
+
+    /**
+     * Whether a set of variants constitutes a valid A/B test: at least two variants, each with a
+     * non-blank label/id key. A single variant (or none) is a plain broadcast, not an A/B test.
+     */
+    fun isAbTest(variantLabels: List<String>?): Boolean =
+        (variantLabels?.count { it.isNotBlank() } ?: 0) >= 2
+
+    /**
+     * Determine the winning variant id by the higher of open-rate then click-rate (click-rate is
+     * the tie-breaker). Returns null when there are no variants or all rates are zero (no signal).
+     * [variants] is a list of (variantId, openRate, clickRate).
+     */
+    fun pickWinner(variants: List<Triple<String, Double, Double>>): String? {
+        if (variants.isEmpty()) return null
+        val best = variants.maxWithOrNull(
+            compareBy<Triple<String, Double, Double>> { it.second }.thenBy { it.third },
+        ) ?: return null
+        if (best.second <= 0.0 && best.third <= 0.0) return null
+        return best.first
+    }
+
+    // ── Email-template merge-var validation ───────────────────────────────────
+
+    // Mirror the server regex app/services/marketing_email_templates.py::_VAR_RE = {{ var }}.
+    private val VAR_RE = Regex("""\{\{\s*([a-zA-Z0-9_]+)\s*\}\}""")
+
+    /**
+     * Extract the distinct merge-var names referenced by a subject + body (sorted, de-duplicated),
+     * matching the server's _extract_variables. Null / blank inputs contribute nothing.
+     */
+    fun extractTemplateVars(subject: String?, body: String?): List<String> {
+        val text = (subject ?: "") + (body ?: "")
+        return VAR_RE.findAll(text).map { it.groupValues[1] }.toSortedSet().toList()
+    }
+
+    /**
+     * The subset of [extractTemplateVars] that a [sampleVars] map does NOT satisfy (missing key or
+     * blank value). Sorted, distinct. Mirrors the server's merge_vars_missing computation.
+     */
+    fun missingTemplateVars(subject: String?, body: String?, sampleVars: Map<String, String>?): List<String> {
+        val vars = extractTemplateVars(subject, body)
+        val provided = sampleVars ?: emptyMap()
+        return vars.filter { provided[it].isNullOrBlank() }
+    }
+
+    /** A template is preview-ready when every referenced merge var has a non-blank sample value. */
+    fun isTemplateComplete(subject: String?, body: String?, sampleVars: Map<String, String>?): Boolean =
+        missingTemplateVars(subject, body, sampleVars).isEmpty()
+
+    /**
+     * Client-side create/edit validation for an email template. Returns null when valid, or a
+     * human message for the first failing rule (mirrors the server field constraints: name 1..120,
+     * subject 1..500, body 1..50000).
+     */
+    fun validateTemplateInput(name: String?, subject: String?, bodyHtml: String?): String? {
+        val n = name?.trim().orEmpty()
+        if (n.isEmpty()) return "A template name is required."
+        if (n.length > 120) return "The template name is too long (max 120)."
+        val s = subject?.trim().orEmpty()
+        if (s.isEmpty()) return "A subject line is required."
+        if (s.length > 500) return "The subject line is too long (max 500)."
+        val b = bodyHtml.orEmpty()
+        if (b.isBlank()) return "The email body cannot be empty."
+        if (b.length > 50_000) return "The email body is too long (max 50,000)."
+        return null
+    }
+
+    /**
+     * Client-side create/edit validation for a campaign. Returns null when valid, else a message.
+     * Mirrors CrmCampaignCreateIn: name 1..200, objective <=500, budget_cents >= 0.
+     */
+    fun validateCampaignInput(name: String?, objective: String?, budgetCents: Long?): String? {
+        val n = name?.trim().orEmpty()
+        if (n.isEmpty()) return "A campaign name is required."
+        if (n.length > 200) return "The campaign name is too long (max 200)."
+        if ((objective?.length ?: 0) > 500) return "The objective is too long (max 500)."
+        if ((budgetCents ?: 0L) < 0L) return "The budget cannot be negative."
+        return null
+    }
+
+    /** Curated campaign-type keys for the editor chip row (mirror the server pattern). */
+    val CAMPAIGN_TYPES: List<String> = listOf("email", "phone", "mail", "fax", "sms")
+
+    /**
+     * Parse a user-entered budget in dollars ("1,234.50", "$12", "") into integer cents. Returns
+     * null when the input is present but not parseable; blank → 0. Tolerant of $ and thousands
+     * separators.
+     */
+    fun parseBudgetToCents(raw: String?): Long? {
+        val cleaned = raw?.trim()?.removePrefix("$")?.replace(",", "")?.trim().orEmpty()
+        if (cleaned.isEmpty()) return 0L
+        val d = cleaned.toDoubleOrNull() ?: return null
+        if (d < 0) return null
+        return kotlin.math.round(d * 100.0).toLong()
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmDataModule.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmDataModule.kt
@@ -33,6 +33,22 @@ object CrmApiModule {
     @Provides
     @Singleton
     fun provideCrmCampaignsApi(retrofit: Retrofit): CrmCampaignsApi = retrofit.create(CrmCampaignsApi::class.java)
+
+    // CMP - campaign write/send/preview, email templates, admin leads on the same Retrofit.
+    @Provides
+    @Singleton
+    fun provideCrmCampaignsWriteApi(retrofit: Retrofit): CrmCampaignsWriteApi =
+        retrofit.create(CrmCampaignsWriteApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCrmEmailTemplatesApi(retrofit: Retrofit): CrmEmailTemplatesApi =
+        retrofit.create(CrmEmailTemplatesApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCrmMarketingAdminApi(retrofit: Retrofit): CrmMarketingAdminApi =
+        retrofit.create(CrmMarketingAdminApi::class.java)
 }
 
 /** CRM-AND-1 — binds the CRM repositories to their implementations. */
@@ -60,4 +76,12 @@ abstract class CrmDataModule {
     @Binds
     @Singleton
     abstract fun bindCrmCampaignsRepository(impl: CrmCampaignsRepositoryImpl): CrmCampaignsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCrmEmailTemplatesRepository(impl: CrmEmailTemplatesRepositoryImpl): CrmEmailTemplatesRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCrmMarketingAdminRepository(impl: CrmMarketingAdminRepositoryImpl): CrmMarketingAdminRepository
 }

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecApi.kt
@@ -305,3 +305,84 @@ interface CrmCampaignsApi {
     @GET("ui/crm-marketing/campaigns/{campaignId}/attribution")
     suspend fun getAttribution(@Path("campaignId") campaignId: String): CrmCampaignAttributionDto
 }
+
+// ─── Campaigns: CMP additions (create/update/delete/send/preview/ab-results) ──
+// Mirrors frontend/src/api/endpoints/crmCampaigns.ts + crmEmail.ts.
+
+interface CrmCampaignsWriteApi {
+
+    @POST("ui/crm-marketing/campaigns")
+    suspend fun createCampaign(@Body body: CrmCampaignCreateInDto): CrmCampaignFullDto
+
+    // Full campaign detail (richer than the compact list DTO).
+    @GET("ui/crm-marketing/campaigns/{campaignId}")
+    suspend fun getCampaignFull(@Path("campaignId") campaignId: String): CrmCampaignFullDto
+
+    @PATCH("ui/crm-marketing/campaigns/{campaignId}")
+    suspend fun updateCampaign(
+        @Path("campaignId") campaignId: String,
+        @Body body: CrmCampaignUpdateInDto,
+    ): CrmCampaignFullDto
+
+    @DELETE("ui/crm-marketing/campaigns/{campaignId}")
+    suspend fun deleteCampaign(@Path("campaignId") campaignId: String)
+
+    @POST("ui/crm-marketing/campaigns/{campaignId}/send")
+    suspend fun sendCampaign(
+        @Path("campaignId") campaignId: String,
+        @Body body: CrmCampaignSendInDto,
+    ): CrmCampaignSendOutDto
+
+    @GET("ui/crm-marketing/campaigns/{campaignId}/ab-results")
+    suspend fun getAbResults(@Path("campaignId") campaignId: String): CrmAbResultsDto
+
+    @POST("ui/crm-marketing/campaigns/{campaignId}/preview-email")
+    suspend fun previewCampaignEmail(
+        @Path("campaignId") campaignId: String,
+        @Body body: CrmEmailPreviewInDto,
+    ): CrmEmailPreviewOutDto
+}
+
+// ─── Email templates: prefix /ui/crm-marketing/email-templates (CMP-002) ──────
+
+interface CrmEmailTemplatesApi {
+
+    @POST("ui/crm-marketing/email-templates")
+    suspend fun createTemplate(@Body body: CrmEmailTemplateCreateInDto): CrmEmailTemplateDto
+
+    @GET("ui/crm-marketing/email-templates")
+    suspend fun listTemplates(
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): CrmEmailTemplateListRespDto
+
+    @GET("ui/crm-marketing/email-templates/{templateId}")
+    suspend fun getTemplate(@Path("templateId") templateId: String): CrmEmailTemplateDto
+
+    @PATCH("ui/crm-marketing/email-templates/{templateId}")
+    suspend fun updateTemplate(
+        @Path("templateId") templateId: String,
+        @Body body: CrmEmailTemplateUpdateInDto,
+    ): CrmEmailTemplateDto
+
+    @DELETE("ui/crm-marketing/email-templates/{templateId}")
+    suspend fun deleteTemplate(@Path("templateId") templateId: String)
+
+    @POST("ui/crm-marketing/email-templates/{templateId}/preview")
+    suspend fun previewTemplate(
+        @Path("templateId") templateId: String,
+        @Body body: CrmEmailTemplatePreviewInDto,
+    ): CrmEmailTemplatePreviewOutDto
+}
+
+// ─── Admin: web-to-lead list (CMP-006, admin-gated → 403 for non-admins) ──────
+
+interface CrmMarketingAdminApi {
+
+    @GET("ui/admin/crm-marketing/leads")
+    suspend fun listLeads(
+        @Query("campaign_id") campaignId: String? = null,
+        @Query("limit") limit: Int? = null,
+        @Query("cursor") cursor: String? = null,
+    ): CrmWebLeadListRespDto
+}

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecDtos.kt
@@ -433,3 +433,179 @@ data class CrmProjectAddContactLinkInDto(
     @Json(name = "linked_entity_type") val linkedEntityType: String? = null,
     @Json(name = "note") val note: String? = null,
 )
+
+// ─────────────────  CAMPAIGNS: CMP additions  ─────────────────
+// CMP-001..CMP-008 — campaign CRUD/send/preview/ab-results + email-template editor + admin leads.
+// Mirrors frontend/src/api/endpoints/crmCampaigns.ts + crmEmail.ts (app/routers/crm_campaigns.py).
+
+// Full campaign shape (extends the compact list DTO's fields the earlier list view used).
+@JsonClass(generateAdapter = true)
+data class CrmCampaignFullDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "owner_id") val ownerId: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "status") val status: String = "",
+    @Json(name = "objective") val objective: String? = null,
+    @Json(name = "budget_cents") val budgetCents: Long = 0,
+    @Json(name = "contact_list_ids") val contactListIds: List<String> = emptyList(),
+    @Json(name = "segment_ids") val segmentIds: List<String> = emptyList(),
+    @Json(name = "tracking_code") val trackingCode: String? = null,
+    @Json(name = "email_template_id") val emailTemplateId: String? = null,
+    @Json(name = "questionnaire_id") val questionnaireId: String? = null,
+    @Json(name = "questionnaire_url") val questionnaireUrl: String? = null,
+    @Json(name = "campaign_type") val campaignType: String = "email",
+    @Json(name = "variants") val variants: List<Map<String, Any?>>? = null,
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "objective") val objective: String? = null,
+    @Json(name = "budget_cents") val budgetCents: Long? = null,
+    @Json(name = "contact_list_ids") val contactListIds: List<String>? = null,
+    @Json(name = "segment_ids") val segmentIds: List<String>? = null,
+    @Json(name = "tracking_code") val trackingCode: String? = null,
+    @Json(name = "start_date") val startDate: String? = null,
+    @Json(name = "end_date") val endDate: String? = null,
+    @Json(name = "campaign_type") val campaignType: String? = null,
+    @Json(name = "email_template_id") val emailTemplateId: String? = null,
+    @Json(name = "questionnaire_id") val questionnaireId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignUpdateInDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "objective") val objective: String? = null,
+    @Json(name = "budget_cents") val budgetCents: Long? = null,
+    @Json(name = "contact_list_ids") val contactListIds: List<String>? = null,
+    @Json(name = "segment_ids") val segmentIds: List<String>? = null,
+    @Json(name = "tracking_code") val trackingCode: String? = null,
+    @Json(name = "start_date") val startDate: String? = null,
+    @Json(name = "end_date") val endDate: String? = null,
+    @Json(name = "campaign_type") val campaignType: String? = null,
+    @Json(name = "email_template_id") val emailTemplateId: String? = null,
+    @Json(name = "questionnaire_id") val questionnaireId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignSendInDto(
+    @Json(name = "dry_run") val dryRun: Boolean = false,
+    @Json(name = "snapshot_ts") val snapshotTs: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmCampaignSendOutDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "total_resolved") val totalResolved: Int = 0,
+    @Json(name = "total_sent") val totalSent: Int = 0,
+    @Json(name = "total_skipped") val totalSkipped: Int = 0,
+    @Json(name = "dry_run") val dryRun: Boolean = false,
+    @Json(name = "send_id") val sendId: String? = null,
+)
+
+// CMP-007 — A/B test results.
+@JsonClass(generateAdapter = true)
+data class CrmAbVariantStatsDto(
+    @Json(name = "variant_id") val variantId: String = "",
+    @Json(name = "label") val label: String = "",
+    @Json(name = "sent") val sent: Int = 0,
+    @Json(name = "opens") val opens: Int = 0,
+    @Json(name = "clicks") val clicks: Int = 0,
+    @Json(name = "open_rate") val openRate: Double = 0.0,
+    @Json(name = "click_rate") val clickRate: Double = 0.0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmAbResultsDto(
+    @Json(name = "campaign_id") val campaignId: String = "",
+    @Json(name = "variant_stats") val variantStats: List<CrmAbVariantStatsDto> = emptyList(),
+)
+
+// CMP-008 — merge-tag email preview.
+@JsonClass(generateAdapter = true)
+data class CrmEmailPreviewInDto(
+    @Json(name = "sample_party_id") val samplePartyId: String? = null,
+    @Json(name = "sample_vars") val sampleVars: Map<String, String> = emptyMap(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEmailPreviewOutDto(
+    @Json(name = "subject") val subject: String = "",
+    @Json(name = "body_text") val bodyText: String = "",
+    @Json(name = "body_html") val bodyHtml: String? = null,
+    @Json(name = "merge_vars_used") val mergeVarsUsed: Map<String, String> = emptyMap(),
+    @Json(name = "merge_vars_missing") val mergeVarsMissing: List<String> = emptyList(),
+)
+
+// CMP-002 — HTML email templates.
+@JsonClass(generateAdapter = true)
+data class CrmEmailTemplateDto(
+    @Json(name = "template_id") val templateId: String = "",
+    @Json(name = "owner_id") val ownerId: String? = null,
+    @Json(name = "name") val name: String = "",
+    @Json(name = "subject_template") val subjectTemplate: String = "",
+    @Json(name = "body_html_template") val bodyHtmlTemplate: String = "",
+    @Json(name = "variables") val variables: List<String> = emptyList(),
+    @Json(name = "status") val status: String = "draft",
+    @Json(name = "created_at") val createdAt: Long = 0,
+    @Json(name = "updated_at") val updatedAt: Long = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEmailTemplateListRespDto(
+    @Json(name = "templates") val templates: List<CrmEmailTemplateDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+    @Json(name = "count") val count: Int = 0,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEmailTemplateCreateInDto(
+    @Json(name = "name") val name: String,
+    @Json(name = "subject_template") val subjectTemplate: String,
+    @Json(name = "body_html_template") val bodyHtmlTemplate: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEmailTemplateUpdateInDto(
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "subject_template") val subjectTemplate: String? = null,
+    @Json(name = "body_html_template") val bodyHtmlTemplate: String? = null,
+    @Json(name = "status") val status: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEmailTemplatePreviewInDto(
+    @Json(name = "sample_vars") val sampleVars: Map<String, String> = emptyMap(),
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmEmailTemplatePreviewOutDto(
+    @Json(name = "subject") val subject: String = "",
+    @Json(name = "body_html") val bodyHtml: String = "",
+    @Json(name = "variables") val variables: List<String> = emptyList(),
+    @Json(name = "missing_vars") val missingVars: List<String> = emptyList(),
+)
+
+// CMP-006 — admin web-to-lead list (server returns leads as loose dicts).
+@JsonClass(generateAdapter = true)
+data class CrmWebLeadDto(
+    @Json(name = "capture_id") val captureId: String = "",
+    @Json(name = "first_name") val firstName: String? = null,
+    @Json(name = "last_name") val lastName: String? = null,
+    @Json(name = "email") val email: String? = null,
+    @Json(name = "phone") val phone: String? = null,
+    @Json(name = "company") val company: String? = null,
+    @Json(name = "message") val message: String? = null,
+    @Json(name = "campaign_id") val campaignId: String? = null,
+    @Json(name = "source_ip") val sourceIp: String? = null,
+    @Json(name = "created_at") val createdAt: Long? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class CrmWebLeadListRespDto(
+    @Json(name = "leads") val leads: List<CrmWebLeadDto> = emptyList(),
+    @Json(name = "cursor") val cursor: String? = null,
+    @Json(name = "count") val count: Int = 0,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecModels.kt
@@ -363,3 +363,179 @@ fun CrmProjectContactLinkDto.toDomain(): CrmProjectContactLink = CrmProjectConta
     addedAt = addedAt,
     note = note,
 )
+
+// ─────────────────  CAMPAIGNS: CMP domain + mappers  ─────────────────
+// CMP-001..CMP-008 — full campaign, send result, A/B results, email template, preview, web lead.
+
+/** Full campaign (extends the compact list projection). Fields default so the compact list DTO
+ *  → domain mapping stays valid. */
+data class CrmCampaignFull(
+    val campaignId: String,
+    val name: String,
+    val status: String,
+    val objective: String?,
+    val budgetCents: Long,
+    val contactListIds: List<String>,
+    val segmentIds: List<String>,
+    val trackingCode: String?,
+    val emailTemplateId: String?,
+    val questionnaireId: String?,
+    val questionnaireUrl: String?,
+    val campaignType: String,
+    val variantLabels: List<String>,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class CrmCampaignSendResult(
+    val campaignId: String,
+    val totalResolved: Int,
+    val totalSent: Int,
+    val totalSkipped: Int,
+    val dryRun: Boolean,
+    val sendId: String?,
+)
+
+data class CrmAbVariantStats(
+    val variantId: String,
+    val label: String,
+    val sent: Int,
+    val opens: Int,
+    val clicks: Int,
+    val openRate: Double,
+    val clickRate: Double,
+)
+
+data class CrmAbResults(
+    val campaignId: String,
+    val variants: List<CrmAbVariantStats>,
+)
+
+data class CrmEmailPreview(
+    val subject: String,
+    val bodyText: String,
+    val bodyHtml: String?,
+    val mergeVarsUsed: Map<String, String>,
+    val mergeVarsMissing: List<String>,
+)
+
+data class CrmEmailTemplate(
+    val templateId: String,
+    val name: String,
+    val subjectTemplate: String,
+    val bodyHtmlTemplate: String,
+    val variables: List<String>,
+    val status: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class CrmEmailTemplatePreview(
+    val subject: String,
+    val bodyHtml: String,
+    val variables: List<String>,
+    val missingVars: List<String>,
+)
+
+data class CrmWebLead(
+    val captureId: String,
+    val firstName: String?,
+    val lastName: String?,
+    val email: String?,
+    val phone: String?,
+    val company: String?,
+    val message: String?,
+    val campaignId: String?,
+    val sourceIp: String?,
+    val createdAt: Long?,
+)
+
+// ── Mappers ──────────────────────────────────────────────────────────────────
+
+private fun variantLabelsOf(variants: List<Map<String, Any?>>?): List<String> =
+    variants.orEmpty().mapIndexed { i, v ->
+        (v["label"] as? String)?.takeIf { it.isNotBlank() }
+            ?: (v["variant_id"] as? String)?.takeIf { it.isNotBlank() }
+            ?: "Variant ${('A' + i)}"
+    }
+
+fun CrmCampaignFullDto.toDomain(): CrmCampaignFull = CrmCampaignFull(
+    campaignId = campaignId,
+    name = name,
+    status = status,
+    objective = objective,
+    budgetCents = budgetCents,
+    contactListIds = contactListIds,
+    segmentIds = segmentIds,
+    trackingCode = trackingCode,
+    emailTemplateId = emailTemplateId,
+    questionnaireId = questionnaireId,
+    questionnaireUrl = questionnaireUrl,
+    campaignType = campaignType,
+    variantLabels = variantLabelsOf(variants),
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun CrmCampaignSendOutDto.toDomain(): CrmCampaignSendResult = CrmCampaignSendResult(
+    campaignId = campaignId,
+    totalResolved = totalResolved,
+    totalSent = totalSent,
+    totalSkipped = totalSkipped,
+    dryRun = dryRun,
+    sendId = sendId,
+)
+
+fun CrmAbVariantStatsDto.toDomain(): CrmAbVariantStats = CrmAbVariantStats(
+    variantId = variantId,
+    label = label,
+    sent = sent,
+    opens = opens,
+    clicks = clicks,
+    openRate = openRate,
+    clickRate = clickRate,
+)
+
+fun CrmAbResultsDto.toDomain(): CrmAbResults = CrmAbResults(
+    campaignId = campaignId,
+    variants = variantStats.map { it.toDomain() },
+)
+
+fun CrmEmailPreviewOutDto.toDomain(): CrmEmailPreview = CrmEmailPreview(
+    subject = subject,
+    bodyText = bodyText,
+    bodyHtml = bodyHtml,
+    mergeVarsUsed = mergeVarsUsed,
+    mergeVarsMissing = mergeVarsMissing,
+)
+
+fun CrmEmailTemplateDto.toDomain(): CrmEmailTemplate = CrmEmailTemplate(
+    templateId = templateId,
+    name = name,
+    subjectTemplate = subjectTemplate,
+    bodyHtmlTemplate = bodyHtmlTemplate,
+    variables = variables,
+    status = status,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun CrmEmailTemplatePreviewOutDto.toDomain(): CrmEmailTemplatePreview = CrmEmailTemplatePreview(
+    subject = subject,
+    bodyHtml = bodyHtml,
+    variables = variables,
+    missingVars = missingVars,
+)
+
+fun CrmWebLeadDto.toDomain(): CrmWebLead = CrmWebLead(
+    captureId = captureId,
+    firstName = firstName,
+    lastName = lastName,
+    email = email,
+    phone = phone,
+    company = company,
+    message = message,
+    campaignId = campaignId,
+    sourceIp = sourceIp,
+    createdAt = createdAt,
+)

--- a/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
+++ b/android/app/src/main/java/com/testlogon/android/data/crm/CrmPecRepository.kt
@@ -458,11 +458,21 @@ class CrmEventsRepositoryImpl @Inject constructor(
 interface CrmCampaignsRepository {
     suspend fun list(status: String? = null): ApiResult<CrmCampaignsPage>
     suspend fun detail(campaignId: String): ApiResult<CrmCampaignDetail>
+
+    // CMP-001..CMP-008 — campaign write/send/preview/ab-results.
+    suspend fun campaignFull(campaignId: String): ApiResult<CrmCampaignFull>
+    suspend fun create(body: CrmCampaignCreateInDto): ApiResult<CrmCampaignFull>
+    suspend fun update(campaignId: String, body: CrmCampaignUpdateInDto): ApiResult<CrmCampaignFull>
+    suspend fun delete(campaignId: String): ApiResult<Unit>
+    suspend fun send(campaignId: String, dryRun: Boolean): ApiResult<CrmCampaignSendResult>
+    suspend fun abResults(campaignId: String): ApiResult<CrmAbResults?>
+    suspend fun previewEmail(campaignId: String, samplePartyId: String?, sampleVars: Map<String, String>): ApiResult<CrmEmailPreview>
 }
 
 @Singleton
 class CrmCampaignsRepositoryImpl @Inject constructor(
     private val api: CrmCampaignsApi,
+    private val writeApi: CrmCampaignsWriteApi,
     private val errorParser: ApiErrorParser,
 ) : CrmCampaignsRepository {
 
@@ -492,6 +502,46 @@ class CrmCampaignsRepositoryImpl @Inject constructor(
         }
     }
 
+
+    override suspend fun campaignFull(campaignId: String): ApiResult<CrmCampaignFull> = withContext(io) {
+        call { writeApi.getCampaignFull(campaignId).toDomain() }
+    }
+
+    override suspend fun create(body: CrmCampaignCreateInDto): ApiResult<CrmCampaignFull> = withContext(io) {
+        call { writeApi.createCampaign(body).toDomain() }
+    }
+
+    override suspend fun update(campaignId: String, body: CrmCampaignUpdateInDto): ApiResult<CrmCampaignFull> =
+        withContext(io) { call { writeApi.updateCampaign(campaignId, body).toDomain() } }
+
+    override suspend fun delete(campaignId: String): ApiResult<Unit> = withContext(io) {
+        call { writeApi.deleteCampaign(campaignId) }
+    }
+
+    override suspend fun send(campaignId: String, dryRun: Boolean): ApiResult<CrmCampaignSendResult> = withContext(io) {
+        call { writeApi.sendCampaign(campaignId, CrmCampaignSendInDto(dryRun = dryRun)).toDomain() }
+    }
+
+    override suspend fun abResults(campaignId: String): ApiResult<CrmAbResults?> = withContext(io) {
+        when (val r = call { writeApi.getAbResults(campaignId).toDomain() }) {
+            is ApiResult.Success -> r
+            is ApiResult.Failure -> if (r.error.status == 404) ApiResult.Success(null) else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun previewEmail(
+        campaignId: String,
+        samplePartyId: String?,
+        sampleVars: Map<String, String>,
+    ): ApiResult<CrmEmailPreview> = withContext(io) {
+        call {
+            writeApi.previewCampaignEmail(
+                campaignId,
+                CrmEmailPreviewInDto(samplePartyId = samplePartyId?.ifBlank { null }, sampleVars = sampleVars),
+            ).toDomain()
+        }
+    }
     private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)
 }
 
@@ -507,4 +557,107 @@ private suspend fun <T> runCatchingApi(
     ApiResult.Failure(errorParser.from(e))
 } catch (e: IOException) {
     ApiResult.NetworkError(e, isTimeout = e is SocketTimeoutException)
+}
+
+// ──────────────────  EMAIL TEMPLATES (CMP-002)  ──────────────────
+
+data class CrmEmailTemplatesPage(
+    val templates: List<CrmEmailTemplate>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+)
+
+interface CrmEmailTemplatesRepository {
+    suspend fun list(): ApiResult<CrmEmailTemplatesPage>
+    suspend fun get(templateId: String): ApiResult<CrmEmailTemplate>
+    suspend fun create(name: String, subject: String, bodyHtml: String): ApiResult<CrmEmailTemplate>
+    suspend fun update(templateId: String, body: CrmEmailTemplateUpdateInDto): ApiResult<CrmEmailTemplate>
+    suspend fun delete(templateId: String): ApiResult<Unit>
+    suspend fun preview(templateId: String, sampleVars: Map<String, String>): ApiResult<CrmEmailTemplatePreview>
+}
+
+@Singleton
+class CrmEmailTemplatesRepositoryImpl @Inject constructor(
+    private val api: CrmEmailTemplatesApi,
+    private val errorParser: ApiErrorParser,
+) : CrmEmailTemplatesRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun list(): ApiResult<CrmEmailTemplatesPage> = withContext(io) {
+        when (val r = call { api.listTemplates() }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmEmailTemplatesPage(r.data.templates.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure ->
+                if (r.error.status == 404) ApiResult.Success(CrmEmailTemplatesPage(emptyList(), null, moduleDisabled = true))
+                else r
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    override suspend fun get(templateId: String): ApiResult<CrmEmailTemplate> = withContext(io) {
+        call { api.getTemplate(templateId).toDomain() }
+    }
+
+    override suspend fun create(name: String, subject: String, bodyHtml: String): ApiResult<CrmEmailTemplate> =
+        withContext(io) {
+            call {
+                api.createTemplate(
+                    CrmEmailTemplateCreateInDto(name = name, subjectTemplate = subject, bodyHtmlTemplate = bodyHtml),
+                ).toDomain()
+            }
+        }
+
+    override suspend fun update(templateId: String, body: CrmEmailTemplateUpdateInDto): ApiResult<CrmEmailTemplate> =
+        withContext(io) { call { api.updateTemplate(templateId, body).toDomain() } }
+
+    override suspend fun delete(templateId: String): ApiResult<Unit> = withContext(io) {
+        call { api.deleteTemplate(templateId) }
+    }
+
+    override suspend fun preview(templateId: String, sampleVars: Map<String, String>): ApiResult<CrmEmailTemplatePreview> =
+        withContext(io) {
+            call { api.previewTemplate(templateId, CrmEmailTemplatePreviewInDto(sampleVars = sampleVars)).toDomain() }
+        }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)
+}
+
+// ──────────────────  ADMIN WEB-TO-LEAD LIST (CMP-006)  ──────────────────
+
+data class CrmWebLeadsPage(
+    val leads: List<CrmWebLead>,
+    val cursor: String?,
+    val moduleDisabled: Boolean = false,
+    val forbidden: Boolean = false,
+)
+
+interface CrmMarketingAdminRepository {
+    suspend fun leads(campaignId: String? = null): ApiResult<CrmWebLeadsPage>
+}
+
+@Singleton
+class CrmMarketingAdminRepositoryImpl @Inject constructor(
+    private val api: CrmMarketingAdminApi,
+    private val errorParser: ApiErrorParser,
+) : CrmMarketingAdminRepository {
+
+    private val io: CoroutineDispatcher = Dispatchers.IO
+
+    override suspend fun leads(campaignId: String?): ApiResult<CrmWebLeadsPage> = withContext(io) {
+        when (val r = call { api.listLeads(campaignId = campaignId?.ifBlank { null }) }) {
+            is ApiResult.Success -> ApiResult.Success(
+                CrmWebLeadsPage(r.data.leads.map { it.toDomain() }, r.data.cursor),
+            )
+            is ApiResult.Failure -> when (r.error.status) {
+                404 -> ApiResult.Success(CrmWebLeadsPage(emptyList(), null, moduleDisabled = true))
+                403 -> ApiResult.Success(CrmWebLeadsPage(emptyList(), null, forbidden = true))
+                else -> r
+            }
+            is ApiResult.NetworkError -> r
+        }
+    }
+
+    private suspend fun <T> call(block: suspend () -> T): ApiResult<T> = runCatchingApi(errorParser, block)
 }

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignExtraScreens.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignExtraScreens.kt
@@ -1,0 +1,520 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.testlogon.android.feature.crm
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.testlogon.android.core.ui.state.EmptyState
+import com.testlogon.android.core.ui.state.ErrorState
+import com.testlogon.android.core.ui.state.LoadingState
+import com.testlogon.android.core.ui.state.OfflineBanner
+import com.testlogon.android.data.crm.CampaignMath
+import com.testlogon.android.data.crm.CrmAbResults
+import com.testlogon.android.data.crm.CrmEmailTemplate
+import com.testlogon.android.data.crm.CrmPecMath
+import com.testlogon.android.data.crm.CrmWebLead
+
+object CrmMarketingTestTags {
+    const val EDITOR = "crm_campaign_editor"
+    const val TEMPLATES = "crm_email_templates"
+    const val LEADS = "crm_marketing_leads"
+}
+
+// ═══════════════════════════  Campaign editor  ═══════════════════════════
+
+@Composable
+fun CrmCampaignEditorRoute(
+    onBack: () -> Unit,
+    onSaved: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmCampaignEditorViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(state.savedCampaignId) {
+        state.savedCampaignId?.let { onSaved(it); viewModel.consumeSaved() }
+    }
+    CrmCampaignEditorScreen(
+        state = state,
+        onBack = onBack,
+        onName = viewModel::onName,
+        onObjective = viewModel::onObjective,
+        onBudget = viewModel::onBudget,
+        onCampaignType = viewModel::onCampaignType,
+        onContactLists = viewModel::onContactLists,
+        onSegments = viewModel::onSegments,
+        onTrackingCode = viewModel::onTrackingCode,
+        onEmailTemplateId = viewModel::onEmailTemplateId,
+        onSave = viewModel::save,
+        onSend = viewModel::send,
+        onPreview = viewModel::loadPreview,
+        onDismissSendResult = viewModel::dismissSendResult,
+        onDismissPreview = viewModel::dismissPreview,
+        onRetry = viewModel::onRetry,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmCampaignEditorScreen(
+    state: CrmCampaignEditorUiState,
+    onBack: () -> Unit,
+    onName: (String) -> Unit,
+    onObjective: (String) -> Unit,
+    onBudget: (String) -> Unit,
+    onCampaignType: (String) -> Unit,
+    onContactLists: (String) -> Unit,
+    onSegments: (String) -> Unit,
+    onTrackingCode: (String) -> Unit,
+    onEmailTemplateId: (String) -> Unit,
+    onSave: () -> Unit,
+    onSend: (Boolean) -> Unit,
+    onPreview: () -> Unit,
+    onDismissSendResult: () -> Unit,
+    onDismissPreview: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmMarketingTestTags.EDITOR),
+        topBar = {
+            TopAppBar(
+                title = { Text(if (state.isNew) "New campaign" else "Edit campaign") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmCampaignEditorUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            CrmCampaignEditorUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load this campaign.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            CrmCampaignEditorUiState.Phase.Content -> Column(
+                modifier = Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                OutlinedTextField(state.name, onName, label = { Text("Name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(state.objective, onObjective, label = { Text("Objective (optional)") }, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(state.budget, onBudget, label = { Text("Budget ($)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                Text("Type", style = MaterialTheme.typography.labelMedium)
+                Row(
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    CampaignMath.CAMPAIGN_TYPES.forEach { t ->
+                        FilterChip(
+                            selected = t == state.campaignType,
+                            onClick = { onCampaignType(t) },
+                            label = { Text(CrmPecMath.campaignTypeLabel(t)) },
+                        )
+                    }
+                }
+                OutlinedTextField(state.contactListIdsRaw, onContactLists, label = { Text("Contact list IDs (comma-separated)") }, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(state.segmentIdsRaw, onSegments, label = { Text("Segment IDs (comma-separated)") }, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(state.emailTemplateId, onEmailTemplateId, label = { Text("Email template ID (optional)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(state.trackingCode, onTrackingCode, label = { Text("Tracking code (optional)") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+
+                if (state.formError != null) {
+                    Text(state.formError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+
+                Button(onClick = onSave, enabled = !state.saving, modifier = Modifier.fillMaxWidth()) {
+                    if (state.saving) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text(if (state.isNew) "Create" else "Save")
+                }
+
+                if (state.campaign != null) {
+                    HorizontalDivider()
+                    Text("Send & preview", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    val blocked = state.sendBlockedReason
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                        OutlinedButton(onClick = { onSend(true) }, enabled = !state.sending && state.canSend, modifier = Modifier.weight(1f)) {
+                            Text("Dry run")
+                        }
+                        Button(onClick = { onSend(false) }, enabled = !state.sending && state.canSend, modifier = Modifier.weight(1f)) {
+                            if (state.sending) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Send")
+                        }
+                    }
+                    if (blocked != null) {
+                        Text(blocked, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+                    }
+                    OutlinedButton(onClick = onPreview, enabled = !state.previewLoading, modifier = Modifier.fillMaxWidth()) {
+                        if (state.previewLoading) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Preview email")
+                    }
+                }
+            }
+        }
+    }
+
+    val send = state.sendResult
+    if (send != null) {
+        AlertDialog(
+            onDismissRequest = onDismissSendResult,
+            title = { Text(if (send.dryRun) "Dry run" else "Send complete") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    LabeledValue("Resolved", send.totalResolved.toString())
+                    LabeledValue("Sent", send.totalSent.toString())
+                    LabeledValue("Skipped", send.totalSkipped.toString())
+                }
+            },
+            confirmButton = { TextButton(onClick = onDismissSendResult) { Text("OK") } },
+        )
+    }
+
+    val preview = state.preview
+    if (preview != null) {
+        AlertDialog(
+            onDismissRequest = onDismissPreview,
+            title = { Text("Email preview") },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    LabeledValue("Subject", preview.subject.ifBlank { CrmPecMath.EM_DASH })
+                    Text(preview.bodyText.ifBlank { "(no body)" }, style = MaterialTheme.typography.bodySmall)
+                    if (preview.mergeVarsMissing.isNotEmpty()) {
+                        Text(
+                            "Missing: ${preview.mergeVarsMissing.joinToString(", ")}",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            },
+            confirmButton = { TextButton(onClick = onDismissPreview) { Text("Close") } },
+        )
+    }
+}
+
+// ═══════════════════════════  A/B results (shared)  ═══════════════════════════
+
+@Composable
+fun AbResultsSection(ab: CrmAbResults) {
+    Text("A/B results", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+    val winner = CampaignMath.pickWinner(ab.variants.map { Triple(it.variantId, it.openRate, it.clickRate) })
+    ab.variants.forEach { v ->
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(v.label.ifBlank { v.variantId.ifBlank { "Variant" } }, fontWeight = FontWeight.SemiBold)
+                    if (winner != null && winner == v.variantId) {
+                        AssistChip(onClick = {}, label = { Text("Winning") })
+                    }
+                }
+                LabeledValue("Sent", v.sent.toString())
+                LabeledValue("Opens", "${v.opens} (${CrmPecMath.formatRate(v.openRate)})")
+                LabeledValue("Clicks", "${v.clicks} (${CrmPecMath.formatRate(v.clickRate)})")
+            }
+        }
+    }
+}
+
+// ═══════════════════════════  Email templates  ═══════════════════════════
+
+@Composable
+fun CrmEmailTemplatesRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmEmailTemplatesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmEmailTemplatesScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        onOpenCreate = viewModel::openCreate,
+        onOpenEdit = viewModel::openEdit,
+        onDelete = viewModel::deleteTemplate,
+        onCloseEditor = viewModel::closeEditor,
+        onEditName = viewModel::onEditName,
+        onEditSubject = viewModel::onEditSubject,
+        onEditBody = viewModel::onEditBody,
+        onSave = viewModel::saveTemplate,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmEmailTemplatesScreen(
+    state: CrmEmailTemplatesUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    onOpenCreate: () -> Unit,
+    onOpenEdit: (CrmEmailTemplate) -> Unit,
+    onDelete: (String) -> Unit,
+    onCloseEditor: () -> Unit,
+    onEditName: (String) -> Unit,
+    onEditSubject: (String) -> Unit,
+    onEditBody: (String) -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmMarketingTestTags.TEMPLATES),
+        topBar = {
+            TopAppBar(
+                title = { Text("Email templates") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (state.phase == CrmEmailTemplatesUiState.Phase.Content && !state.moduleDisabled) {
+                FloatingActionButton(onClick = onOpenCreate) {
+                    Icon(Icons.Filled.Add, contentDescription = "New template")
+                }
+            }
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmEmailTemplatesUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            CrmEmailTemplatesUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load templates.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            CrmEmailTemplatesUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.moduleDisabled) InfoBanner("The Marketing module is not enabled for this account.")
+                    if (state.templates.isEmpty()) {
+                        EmptyState(
+                            title = if (state.moduleDisabled) "Templates unavailable" else "No templates yet",
+                            body = if (state.moduleDisabled) null else "Create an HTML email template with the + button.",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(state.templates, key = { it.templateId }) { t ->
+                                TemplateRow(
+                                    template = t,
+                                    deleting = state.busyDeleteId == t.templateId,
+                                    onClick = { onOpenEdit(t) },
+                                    onDelete = { onDelete(t.templateId) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (state.editorOpen) {
+        AlertDialog(
+            onDismissRequest = { if (!state.saving) onCloseEditor() },
+            title = { Text(if (state.editing == null) "New template" else "Edit template") },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedTextField(state.editName, onEditName, label = { Text("Name") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                    OutlinedTextField(state.editSubject, onEditSubject, label = { Text("Subject") }, modifier = Modifier.fillMaxWidth())
+                    OutlinedTextField(state.editBody, onEditBody, label = { Text("HTML body (use {{ var }})") }, modifier = Modifier.fillMaxWidth())
+                    val vars = CampaignMath.extractTemplateVars(state.editSubject, state.editBody)
+                    if (vars.isNotEmpty()) {
+                        Text("Variables: ${vars.joinToString(", ")}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    if (state.formError != null) {
+                        Text(state.formError, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(enabled = !state.saving, onClick = onSave) {
+                    if (state.saving) CircularProgressIndicator(modifier = Modifier.size(18.dp)) else Text("Save")
+                }
+            },
+            dismissButton = { TextButton(enabled = !state.saving, onClick = onCloseEditor) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun TemplateRow(
+    template: CrmEmailTemplate,
+    deleting: Boolean,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(template.name.ifBlank { "(untitled)" }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(template.subjectTemplate.ifBlank { CrmPecMath.EM_DASH }, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            AssistChip(onClick = onClick, label = { Text(CrmPecMath.campaignStatusLabel(template.status)) })
+            IconButton(onClick = onDelete, enabled = !deleting) {
+                if (deleting) CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                else Icon(Icons.Filled.Delete, contentDescription = "Delete")
+            }
+        }
+    }
+}
+
+// ═══════════════════════════  Admin web-to-lead list  ═══════════════════════════
+
+@Composable
+fun CrmMarketingLeadsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CrmMarketingLeadsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    CrmMarketingLeadsScreen(
+        state = state,
+        onBack = onBack,
+        onRefresh = viewModel::onRefresh,
+        onRetry = viewModel::onRetry,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CrmMarketingLeadsScreen(
+    state: CrmMarketingLeadsUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.testTag(CrmMarketingTestTags.LEADS),
+        topBar = {
+            TopAppBar(
+                title = { Text("Web leads") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (state.phase) {
+            CrmMarketingLeadsUiState.Phase.Loading -> LoadingState(modifier = Modifier.padding(padding))
+            CrmMarketingLeadsUiState.Phase.Error -> ErrorState(
+                message = state.errorMessage ?: "Couldn't load leads.",
+                onRetry = onRetry,
+                modifier = Modifier.padding(padding),
+            )
+            CrmMarketingLeadsUiState.Phase.Content -> PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.isOffline) OfflineBanner(onRetry = onRetry)
+                    if (state.forbidden) InfoBanner("Web leads can only be viewed by an administrator.")
+                    if (state.moduleDisabled) InfoBanner("The Marketing module is not enabled for this account.")
+                    if (state.leads.isEmpty()) {
+                        EmptyState(
+                            title = when {
+                                state.forbidden -> "Not available"
+                                state.moduleDisabled -> "Leads unavailable"
+                                else -> "No web leads yet"
+                            },
+                            body = if (state.forbidden || state.moduleDisabled) null else "Captured web-to-lead submissions will appear here.",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(state.leads, key = { it.captureId }) { lead -> LeadRow(lead) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LeadRow(lead: CrmWebLead) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            val name = listOfNotNull(lead.firstName, lead.lastName).joinToString(" ").ifBlank { "(no name)" }
+            Text(name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            if (!lead.email.isNullOrBlank()) LabeledValue("Email", lead.email)
+            if (!lead.company.isNullOrBlank()) LabeledValue("Company", lead.company)
+            if (!lead.phone.isNullOrBlank()) LabeledValue("Phone", lead.phone)
+            LabeledValue("Captured", CrmPecMath.formatDate(lead.createdAt))
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignExtraViewModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignExtraViewModels.kt
@@ -1,0 +1,405 @@
+package com.testlogon.android.feature.crm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CampaignMath
+import com.testlogon.android.data.crm.CrmCampaignCreateInDto
+import com.testlogon.android.data.crm.CrmCampaignFull
+import com.testlogon.android.data.crm.CrmCampaignSendResult
+import com.testlogon.android.data.crm.CrmCampaignUpdateInDto
+import com.testlogon.android.data.crm.CrmCampaignsRepository
+import com.testlogon.android.data.crm.CrmEmailPreview
+import com.testlogon.android.data.crm.CrmEmailTemplate
+import com.testlogon.android.data.crm.CrmEmailTemplateUpdateInDto
+import com.testlogon.android.data.crm.CrmEmailTemplatesRepository
+import com.testlogon.android.data.crm.CrmMarketingAdminRepository
+import com.testlogon.android.data.crm.CrmWebLead
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// ─────────────────────  Campaign editor (create / edit + send + preview)  ─────────────────────
+
+data class CrmCampaignEditorUiState(
+    val phase: Phase = Phase.Loading,
+    val isNew: Boolean = true,
+    val campaign: CrmCampaignFull? = null,
+    // form fields
+    val name: String = "",
+    val objective: String = "",
+    val budget: String = "",
+    val campaignType: String = "email",
+    val contactListIdsRaw: String = "",
+    val segmentIdsRaw: String = "",
+    val trackingCode: String = "",
+    val emailTemplateId: String = "",
+    // actions
+    val saving: Boolean = false,
+    val sending: Boolean = false,
+    val formError: String? = null,
+    val savedCampaignId: String? = null,
+    val sendResult: CrmCampaignSendResult? = null,
+    val preview: CrmEmailPreview? = null,
+    val previewLoading: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+
+    val contactListIds: List<String>
+        get() = contactListIdsRaw.split(',', '\n').map { it.trim() }.filter { it.isNotBlank() }
+    val segmentIds: List<String>
+        get() = segmentIdsRaw.split(',', '\n').map { it.trim() }.filter { it.isNotBlank() }
+
+    val canSend: Boolean
+        get() = campaign != null && CampaignMath.canSend(campaign.status, contactListIds, segmentIds)
+    val sendBlockedReason: String?
+        get() = if (campaign == null) "Save the campaign first." else
+            CampaignMath.sendBlockedReason(campaign.status, contactListIds, segmentIds)
+}
+
+/**
+ * CMP-001..CMP-008 — campaign editor. Create (POST) or load+edit (GET/PATCH) a campaign, run a
+ * dry-run/real send, and fetch a merge-tag email preview. A 404 degrades to a clean error page.
+ * The nav arg is optional: absent → create mode.
+ */
+@HiltViewModel
+class CrmCampaignEditorViewModel @Inject constructor(
+    private val repository: CrmCampaignsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val campaignId: String? =
+        savedStateHandle.get<String>(ARG_CAMPAIGN_ID)?.takeIf { it.isNotBlank() && it != NEW_SENTINEL }
+
+    private val _uiState = MutableStateFlow(CrmCampaignEditorUiState(isNew = campaignId == null))
+    val uiState: StateFlow<CrmCampaignEditorUiState> = _uiState.asStateFlow()
+
+    init {
+        if (campaignId == null) {
+            _uiState.update { it.copy(phase = CrmCampaignEditorUiState.Phase.Content) }
+        } else {
+            load()
+        }
+    }
+
+    fun onRetry() = load()
+
+    private fun load() {
+        val id = campaignId ?: return
+        _uiState.update { it.copy(phase = if (it.campaign == null) CrmCampaignEditorUiState.Phase.Loading else it.phase) }
+        viewModelScope.launch {
+            when (val r = repository.campaignFull(id)) {
+                is ApiResult.Success -> _uiState.update { it.prefill(r.data) }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(phase = CrmCampaignEditorUiState.Phase.Error, isOffline = false, errorMessage = r.error.message)
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(phase = CrmCampaignEditorUiState.Phase.Error, isOffline = true, errorMessage = "You're offline. Try again.")
+                }
+            }
+        }
+    }
+
+    private fun CrmCampaignEditorUiState.prefill(c: CrmCampaignFull): CrmCampaignEditorUiState = copy(
+        phase = CrmCampaignEditorUiState.Phase.Content,
+        isNew = false,
+        campaign = c,
+        name = c.name,
+        objective = c.objective.orEmpty(),
+        budget = if (c.budgetCents > 0) (c.budgetCents / 100.0).toString() else "",
+        campaignType = c.campaignType,
+        contactListIdsRaw = c.contactListIds.joinToString(", "),
+        segmentIdsRaw = c.segmentIds.joinToString(", "),
+        trackingCode = c.trackingCode.orEmpty(),
+        emailTemplateId = c.emailTemplateId.orEmpty(),
+        errorMessage = null,
+        isOffline = false,
+    )
+
+    fun onName(v: String) = _uiState.update { it.copy(name = v, formError = null) }
+    fun onObjective(v: String) = _uiState.update { it.copy(objective = v, formError = null) }
+    fun onBudget(v: String) = _uiState.update { it.copy(budget = v, formError = null) }
+    fun onCampaignType(v: String) = _uiState.update { it.copy(campaignType = v) }
+    fun onContactLists(v: String) = _uiState.update { it.copy(contactListIdsRaw = v) }
+    fun onSegments(v: String) = _uiState.update { it.copy(segmentIdsRaw = v) }
+    fun onTrackingCode(v: String) = _uiState.update { it.copy(trackingCode = v) }
+    fun onEmailTemplateId(v: String) = _uiState.update { it.copy(emailTemplateId = v) }
+    fun clearFormError() = _uiState.update { it.copy(formError = null) }
+    fun consumeSaved() = _uiState.update { it.copy(savedCampaignId = null) }
+    fun dismissSendResult() = _uiState.update { it.copy(sendResult = null) }
+    fun dismissPreview() = _uiState.update { it.copy(preview = null) }
+
+    fun save() {
+        val s = _uiState.value
+        val cents = CampaignMath.parseBudgetToCents(s.budget)
+        if (cents == null) {
+            _uiState.update { it.copy(formError = "Enter a valid budget amount.") }
+            return
+        }
+        val err = CampaignMath.validateCampaignInput(s.name, s.objective.ifBlank { null }, cents)
+        if (err != null) {
+            _uiState.update { it.copy(formError = err) }
+            return
+        }
+        _uiState.update { it.copy(saving = true, formError = null) }
+        viewModelScope.launch {
+            val result = if (s.isNew || s.campaign == null) {
+                repository.create(
+                    CrmCampaignCreateInDto(
+                        name = s.name.trim(),
+                        objective = s.objective.ifBlank { null },
+                        budgetCents = cents,
+                        contactListIds = s.contactListIds.ifEmpty { null },
+                        segmentIds = s.segmentIds.ifEmpty { null },
+                        trackingCode = s.trackingCode.ifBlank { null },
+                        campaignType = s.campaignType,
+                        emailTemplateId = s.emailTemplateId.ifBlank { null },
+                    ),
+                )
+            } else {
+                repository.update(
+                    s.campaign.campaignId,
+                    CrmCampaignUpdateInDto(
+                        name = s.name.trim(),
+                        objective = s.objective.ifBlank { null },
+                        budgetCents = cents,
+                        contactListIds = s.contactListIds,
+                        segmentIds = s.segmentIds,
+                        trackingCode = s.trackingCode.ifBlank { null },
+                        campaignType = s.campaignType,
+                        emailTemplateId = s.emailTemplateId.ifBlank { null },
+                    ),
+                )
+            }
+            when (result) {
+                is ApiResult.Success -> _uiState.update {
+                    it.prefill(result.data).copy(saving = false, savedCampaignId = result.data.campaignId)
+                }
+                is ApiResult.Failure -> _uiState.update { it.copy(saving = false, formError = result.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(saving = false, formError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun send(dryRun: Boolean) {
+        val id = _uiState.value.campaign?.campaignId ?: return
+        _uiState.update { it.copy(sending = true, formError = null) }
+        viewModelScope.launch {
+            when (val r = repository.send(id, dryRun)) {
+                is ApiResult.Success -> _uiState.update { it.copy(sending = false, sendResult = r.data) }
+                is ApiResult.Failure -> _uiState.update { it.copy(sending = false, formError = r.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(sending = false, formError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun loadPreview() {
+        val id = _uiState.value.campaign?.campaignId ?: return
+        _uiState.update { it.copy(previewLoading = true) }
+        viewModelScope.launch {
+            when (val r = repository.previewEmail(id, samplePartyId = null, sampleVars = emptyMap())) {
+                is ApiResult.Success -> _uiState.update { it.copy(previewLoading = false, preview = r.data) }
+                is ApiResult.Failure -> _uiState.update { it.copy(previewLoading = false, formError = r.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(previewLoading = false, formError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_CAMPAIGN_ID: String = "campaignId"
+        const val NEW_SENTINEL: String = "new"
+    }
+}
+
+// ─────────────────────────  Email templates (list + editor)  ─────────────────────────
+
+data class CrmEmailTemplatesUiState(
+    val phase: Phase = Phase.Loading,
+    val templates: List<CrmEmailTemplate> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+    // editor dialog
+    val editorOpen: Boolean = false,
+    val editing: CrmEmailTemplate? = null,
+    val editName: String = "",
+    val editSubject: String = "",
+    val editBody: String = "",
+    val saving: Boolean = false,
+    val formError: String? = null,
+    val busyDeleteId: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+@HiltViewModel
+class CrmEmailTemplatesViewModel @Inject constructor(
+    private val repository: CrmEmailTemplatesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CrmEmailTemplatesUiState())
+    val uiState: StateFlow<CrmEmailTemplatesUiState> = _uiState.asStateFlow()
+
+    init { load(fromUser = false) }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.templates.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else CrmEmailTemplatesUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.list()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmEmailTemplatesUiState.Phase.Content,
+                        templates = r.data.templates,
+                        moduleDisabled = r.data.moduleDisabled,
+                        isRefreshing = false, isOffline = false, errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.templates.isNotEmpty()) CrmEmailTemplatesUiState.Phase.Content else CrmEmailTemplatesUiState.Phase.Error,
+                        isRefreshing = false, isOffline = false, errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.templates.isNotEmpty()) CrmEmailTemplatesUiState.Phase.Content else CrmEmailTemplatesUiState.Phase.Error,
+                        isRefreshing = false, isOffline = true, errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun openCreate() = _uiState.update {
+        it.copy(editorOpen = true, editing = null, editName = "", editSubject = "", editBody = "", formError = null)
+    }
+
+    fun openEdit(t: CrmEmailTemplate) = _uiState.update {
+        it.copy(
+            editorOpen = true, editing = t,
+            editName = t.name, editSubject = t.subjectTemplate, editBody = t.bodyHtmlTemplate, formError = null,
+        )
+    }
+
+    fun closeEditor() = _uiState.update { it.copy(editorOpen = false, formError = null) }
+    fun onEditName(v: String) = _uiState.update { it.copy(editName = v, formError = null) }
+    fun onEditSubject(v: String) = _uiState.update { it.copy(editSubject = v, formError = null) }
+    fun onEditBody(v: String) = _uiState.update { it.copy(editBody = v, formError = null) }
+
+    fun saveTemplate() {
+        val s = _uiState.value
+        val err = CampaignMath.validateTemplateInput(s.editName, s.editSubject, s.editBody)
+        if (err != null) { _uiState.update { it.copy(formError = err) }; return }
+        _uiState.update { it.copy(saving = true, formError = null) }
+        viewModelScope.launch {
+            val result = if (s.editing == null) {
+                repository.create(s.editName.trim(), s.editSubject.trim(), s.editBody)
+            } else {
+                repository.update(
+                    s.editing.templateId,
+                    CrmEmailTemplateUpdateInDto(
+                        name = s.editName.trim(),
+                        subjectTemplate = s.editSubject.trim(),
+                        bodyHtmlTemplate = s.editBody,
+                    ),
+                )
+            }
+            when (result) {
+                is ApiResult.Success -> { _uiState.update { it.copy(saving = false, editorOpen = false) }; load(fromUser = false) }
+                is ApiResult.Failure -> _uiState.update { it.copy(saving = false, formError = result.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(saving = false, formError = "You're offline. Try again.") }
+            }
+        }
+    }
+
+    fun deleteTemplate(templateId: String) {
+        _uiState.update { it.copy(busyDeleteId = templateId) }
+        viewModelScope.launch {
+            when (val r = repository.delete(templateId)) {
+                is ApiResult.Success -> { _uiState.update { it.copy(busyDeleteId = null) }; load(fromUser = false) }
+                is ApiResult.Failure -> _uiState.update { it.copy(busyDeleteId = null, errorMessage = r.error.message) }
+                is ApiResult.NetworkError -> _uiState.update { it.copy(busyDeleteId = null, errorMessage = "You're offline. Try again.") }
+            }
+        }
+    }
+}
+
+// ─────────────────────────  Admin web-to-lead list (CMP-006)  ─────────────────────────
+
+data class CrmMarketingLeadsUiState(
+    val phase: Phase = Phase.Loading,
+    val leads: List<CrmWebLead> = emptyList(),
+    val moduleDisabled: Boolean = false,
+    val forbidden: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isOffline: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    enum class Phase { Loading, Content, Error }
+}
+
+@HiltViewModel
+class CrmMarketingLeadsViewModel @Inject constructor(
+    private val repository: CrmMarketingAdminRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CrmMarketingLeadsUiState())
+    val uiState: StateFlow<CrmMarketingLeadsUiState> = _uiState.asStateFlow()
+
+    init { load(fromUser = false) }
+
+    fun onRefresh() = load(fromUser = true)
+    fun onRetry() = load(fromUser = true)
+
+    private fun load(fromUser: Boolean) {
+        val hasContent = _uiState.value.leads.isNotEmpty()
+        _uiState.update {
+            it.copy(
+                phase = if (hasContent) it.phase else CrmMarketingLeadsUiState.Phase.Loading,
+                isRefreshing = fromUser && hasContent,
+            )
+        }
+        viewModelScope.launch {
+            when (val r = repository.leads()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        phase = CrmMarketingLeadsUiState.Phase.Content,
+                        leads = r.data.leads,
+                        moduleDisabled = r.data.moduleDisabled,
+                        forbidden = r.data.forbidden,
+                        isRefreshing = false, isOffline = false, errorMessage = null,
+                    )
+                }
+                is ApiResult.Failure -> _uiState.update {
+                    it.copy(
+                        phase = if (it.leads.isNotEmpty()) CrmMarketingLeadsUiState.Phase.Content else CrmMarketingLeadsUiState.Phase.Error,
+                        isRefreshing = false, isOffline = false, errorMessage = r.error.message,
+                    )
+                }
+                is ApiResult.NetworkError -> _uiState.update {
+                    it.copy(
+                        phase = if (it.leads.isNotEmpty()) CrmMarketingLeadsUiState.Phase.Content else CrmMarketingLeadsUiState.Phase.Error,
+                        isRefreshing = false, isOffline = true, errorMessage = "You're offline. Try again.",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsScreens.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsScreens.kt
@@ -15,9 +15,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,6 +59,9 @@ object CrmCampaignsTestTags {
 @Composable
 fun CrmCampaignsRoute(
     onCampaignClick: (String) -> Unit,
+    onNewCampaign: () -> Unit,
+    onOpenTemplates: () -> Unit,
+    onOpenLeads: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CrmCampaignsViewModel = hiltViewModel(),
@@ -62,6 +70,9 @@ fun CrmCampaignsRoute(
     CrmCampaignsScreen(
         state = state,
         onCampaignClick = onCampaignClick,
+        onNewCampaign = onNewCampaign,
+        onOpenTemplates = onOpenTemplates,
+        onOpenLeads = onOpenLeads,
         onBack = onBack,
         onRefresh = viewModel::onRefresh,
         onRetry = viewModel::onRetry,
@@ -73,6 +84,9 @@ fun CrmCampaignsRoute(
 fun CrmCampaignsScreen(
     state: CrmCampaignsUiState,
     onCampaignClick: (String) -> Unit,
+    onNewCampaign: () -> Unit,
+    onOpenTemplates: () -> Unit,
+    onOpenLeads: () -> Unit,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
@@ -88,7 +102,22 @@ fun CrmCampaignsScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
+                actions = {
+                    IconButton(onClick = onOpenLeads) {
+                        Icon(Icons.Filled.Person, contentDescription = "Web leads")
+                    }
+                    IconButton(onClick = onOpenTemplates) {
+                        Icon(Icons.Filled.Edit, contentDescription = "Email templates")
+                    }
+                },
             )
+        },
+        floatingActionButton = {
+            if (state.phase == CrmCampaignsUiState.Phase.Content && !state.moduleDisabled) {
+                FloatingActionButton(onClick = onNewCampaign) {
+                    Icon(Icons.Filled.Add, contentDescription = "New campaign")
+                }
+            }
         },
     ) { padding ->
         when (state.phase) {
@@ -157,17 +186,19 @@ private fun CampaignRow(campaign: CrmCampaign, onClick: () -> Unit) {
 @Composable
 fun CrmCampaignDetailRoute(
     onBack: () -> Unit,
+    onEdit: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CrmCampaignDetailViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    CrmCampaignDetailScreen(state = state, onBack = onBack, onRetry = viewModel::onRetry, modifier = modifier)
+    CrmCampaignDetailScreen(state = state, onBack = onBack, onEdit = onEdit, onRetry = viewModel::onRetry, modifier = modifier)
 }
 
 @Composable
 fun CrmCampaignDetailScreen(
     state: CrmCampaignDetailUiState,
     onBack: () -> Unit,
+    onEdit: (String) -> Unit,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -179,6 +210,14 @@ fun CrmCampaignDetailScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    val id = state.campaign?.campaignId
+                    if (id != null) {
+                        IconButton(onClick = { onEdit(id) }) {
+                            Icon(Icons.Filled.Edit, contentDescription = "Edit campaign")
+                        }
                     }
                 },
             )
@@ -213,9 +252,15 @@ fun CrmCampaignDetailScreen(
                         LabeledValue("Sent", attr.totalSent.toString())
                         LabeledValue("Opens", "${attr.openCount} (${CrmPecMath.formatRate(attr.openRate)})")
                         LabeledValue("Clicks", "${attr.clickCount} (${CrmPecMath.formatRate(attr.clickRate)})")
-                    } else {
+                    }
+                    val ab = state.abResults
+                    if (ab != null) {
+                        HorizontalDivider()
+                        AbResultsSection(ab)
+                    }
+                    if (attr == null && ab == null) {
                         Text(
-                            "Full campaign editing and A/B testing live in the web console.",
+                            "Tap the edit action to configure audience, send, preview, or run an A/B test.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsViewModels.kt
+++ b/android/app/src/main/java/com/testlogon/android/feature/crm/CrmCampaignsViewModels.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.testlogon.android.core.model.ApiResult
+import com.testlogon.android.data.crm.CrmAbResults
 import com.testlogon.android.data.crm.CrmCampaign
 import com.testlogon.android.data.crm.CrmCampaignAttribution
 import com.testlogon.android.data.crm.CrmCampaignsRepository
@@ -94,6 +95,7 @@ data class CrmCampaignDetailUiState(
     val phase: Phase = Phase.Loading,
     val campaign: CrmCampaign? = null,
     val attribution: CrmCampaignAttribution? = null,
+    val abResults: CrmAbResults? = null,
     val isOffline: Boolean = false,
     val errorMessage: String? = null,
 ) {
@@ -125,14 +127,20 @@ class CrmCampaignDetailViewModel @Inject constructor(
         }
         viewModelScope.launch {
             when (val r = repository.detail(campaignId)) {
-                is ApiResult.Success -> _uiState.update {
-                    it.copy(
-                        phase = CrmCampaignDetailUiState.Phase.Content,
-                        campaign = r.data.campaign,
-                        attribution = r.data.attribution,
-                        isOffline = false,
-                        errorMessage = null,
-                    )
+                is ApiResult.Success -> {
+                    // A/B results are best-effort (only present for multi-variant campaigns; 404 → null).
+                    val ab = (repository.abResults(campaignId) as? ApiResult.Success)?.data
+                        ?.takeIf { it.variants.isNotEmpty() }
+                    _uiState.update {
+                        it.copy(
+                            phase = CrmCampaignDetailUiState.Phase.Content,
+                            campaign = r.data.campaign,
+                            attribution = r.data.attribution,
+                            abResults = ab,
+                            isOffline = false,
+                            errorMessage = null,
+                        )
+                    }
                 }
                 is ApiResult.Failure -> _uiState.update {
                     it.copy(

--- a/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
+++ b/android/app/src/main/java/com/testlogon/android/navigation/CrmNavigation.kt
@@ -28,6 +28,10 @@ import com.testlogon.android.feature.crm.CrmEventDetailViewModel
 import com.testlogon.android.feature.crm.CrmCampaignsRoute
 import com.testlogon.android.feature.crm.CrmCampaignDetailRoute
 import com.testlogon.android.feature.crm.CrmCampaignDetailViewModel
+import com.testlogon.android.feature.crm.CrmCampaignEditorRoute
+import com.testlogon.android.feature.crm.CrmCampaignEditorViewModel
+import com.testlogon.android.feature.crm.CrmEmailTemplatesRoute
+import com.testlogon.android.feature.crm.CrmMarketingLeadsRoute
 
 /** CRM-AND-1 — the CRM leads list route (reached from the More hub / Growth). */
 data object CrmLeadsDest {
@@ -123,6 +127,25 @@ data object CrmCampaignDetailDest {
     const val ROUTE = "crm/campaigns/{$ARG_CAMPAIGN_ID}"
 
     fun build(campaignId: String): String = "crm/campaigns/${Uri.encode(campaignId)}"
+}
+
+/** CMP — the campaign editor (create / edit). The path arg is the campaign id, or "new" to create. */
+data object CrmCampaignEditorDest {
+    const val ARG_CAMPAIGN_ID = CrmCampaignEditorViewModel.ARG_CAMPAIGN_ID
+    const val ROUTE = "crm/campaigns/editor/{$ARG_CAMPAIGN_ID}"
+
+    fun build(campaignId: String?): String =
+        "crm/campaigns/editor/" + Uri.encode(campaignId?.ifBlank { null } ?: CrmCampaignEditorViewModel.NEW_SENTINEL)
+}
+
+/** CMP-002 — the HTML email-template editor list route. */
+data object CrmEmailTemplatesDest {
+    const val ROUTE = "crm/email-templates"
+}
+
+/** CMP-006 — the admin web-to-lead list route (server admin-gated → 403 surfaced as a banner). */
+data object CrmMarketingLeadsDest {
+    const val ROUTE = "crm/marketing-leads"
 }
 
 /** CRM-AND-1 — registers the CRM leads list + detail + pipeline destinations in the authenticated graph. */
@@ -226,6 +249,15 @@ fun NavGraphBuilder.crmDestinations(navController: NavHostController) {
             onCampaignClick = { id ->
                 navController.navigate(CrmCampaignDetailDest.build(id)) { launchSingleTop = true }
             },
+            onNewCampaign = {
+                navController.navigate(CrmCampaignEditorDest.build(null)) { launchSingleTop = true }
+            },
+            onOpenTemplates = {
+                navController.navigate(CrmEmailTemplatesDest.ROUTE) { launchSingleTop = true }
+            },
+            onOpenLeads = {
+                navController.navigate(CrmMarketingLeadsDest.ROUTE) { launchSingleTop = true }
+            },
             onBack = { navController.popBackStack() },
         )
     }
@@ -235,6 +267,28 @@ fun NavGraphBuilder.crmDestinations(navController: NavHostController) {
             navArgument(CrmCampaignDetailDest.ARG_CAMPAIGN_ID) { type = NavType.StringType },
         ),
     ) {
-        CrmCampaignDetailRoute(onBack = { navController.popBackStack() })
+        CrmCampaignDetailRoute(
+            onBack = { navController.popBackStack() },
+            onEdit = { id ->
+                navController.navigate(CrmCampaignEditorDest.build(id)) { launchSingleTop = true }
+            },
+        )
+    }
+    composable(
+        route = CrmCampaignEditorDest.ROUTE,
+        arguments = listOf(
+            navArgument(CrmCampaignEditorDest.ARG_CAMPAIGN_ID) { type = NavType.StringType },
+        ),
+    ) {
+        CrmCampaignEditorRoute(
+            onBack = { navController.popBackStack() },
+            onSaved = { navController.popBackStack() },
+        )
+    }
+    composable(CrmEmailTemplatesDest.ROUTE) {
+        CrmEmailTemplatesRoute(onBack = { navController.popBackStack() })
+    }
+    composable(CrmMarketingLeadsDest.ROUTE) {
+        CrmMarketingLeadsRoute(onBack = { navController.popBackStack() })
     }
 }

--- a/android/app/src/test/java/com/testlogon/android/data/crm/CampaignMathTest.kt
+++ b/android/app/src/test/java/com/testlogon/android/data/crm/CampaignMathTest.kt
@@ -1,0 +1,181 @@
+package com.testlogon.android.data.crm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * CMP — JVM unit tests for the pure Campaign logic (send eligibility, A/B split, merge-var
+ * validation, budget parsing). No Android types; degrade-on-bad-input is asserted so the UI never
+ * crashes on a 404 (module disabled) or dev-host drift.
+ */
+class CampaignMathTest {
+
+    // ── Send eligibility ──────────────────────────────────────────────────────
+
+    @Test
+    fun hasAudience_countsListsAndSegmentsIgnoringBlanks() {
+        assertFalse(CampaignMath.hasAudience(null, null))
+        assertFalse(CampaignMath.hasAudience(emptyList(), emptyList()))
+        assertFalse(CampaignMath.hasAudience(listOf("", "  "), listOf("")))
+        assertTrue(CampaignMath.hasAudience(listOf("l1"), null))
+        assertTrue(CampaignMath.hasAudience(null, listOf("s1")))
+        assertEquals(3, CampaignMath.audienceSourceCount(listOf("l1", "l2"), listOf("s1")))
+    }
+
+    @Test
+    fun canSend_requiresAudienceAndNonTerminalStatus() {
+        assertTrue(CampaignMath.canSend("draft", listOf("l1"), null))
+        assertTrue(CampaignMath.canSend(null, listOf("l1"), null))
+        assertTrue(CampaignMath.canSend("", null, listOf("s1")))
+        // no audience blocks
+        assertFalse(CampaignMath.canSend("draft", null, null))
+        // terminal status blocks
+        assertFalse(CampaignMath.canSend("sent", listOf("l1"), null))
+        assertFalse(CampaignMath.canSend("COMPLETED", listOf("l1"), null))
+        assertFalse(CampaignMath.canSend("cancelled", listOf("l1"), null))
+    }
+
+    @Test
+    fun sendBlockedReason_explainsWhy() {
+        assertEquals(
+            "Add a contact list or segment before sending.",
+            CampaignMath.sendBlockedReason("draft", null, null),
+        )
+        assertEquals(
+            "This campaign has already been sent.",
+            CampaignMath.sendBlockedReason("sent", listOf("l1"), null),
+        )
+        assertNull(CampaignMath.sendBlockedReason("draft", listOf("l1"), null))
+    }
+
+    // ── A/B split ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun abSplit_evenlyApportionsAndSumsBack() {
+        assertEquals(listOf(50, 50), CampaignMath.abSplit(100, 2))
+        // remainder goes to earliest variants
+        assertEquals(listOf(4, 3, 3), CampaignMath.abSplit(10, 3))
+        val split = CampaignMath.abSplit(101, 3)
+        assertEquals(101, split.sum())
+        assertEquals(listOf(34, 34, 33), split)
+    }
+
+    @Test
+    fun abSplit_degradesOnBadInput() {
+        assertEquals(emptyList<Int>(), CampaignMath.abSplit(100, 0))
+        assertEquals(emptyList<Int>(), CampaignMath.abSplit(100, -1))
+        assertEquals(listOf(0, 0), CampaignMath.abSplit(0, 2))
+        assertEquals(listOf(0, 0, 0), CampaignMath.abSplit(-5, 3))
+    }
+
+    @Test
+    fun abSplitPercents_evenShares() {
+        assertEquals(listOf(50.0, 50.0), CampaignMath.abSplitPercents(2))
+        assertEquals(listOf(33.3, 33.3, 33.3), CampaignMath.abSplitPercents(3))
+        assertEquals(emptyList<Double>(), CampaignMath.abSplitPercents(0))
+    }
+
+    @Test
+    fun isAbTest_needsTwoLabeledVariants() {
+        assertFalse(CampaignMath.isAbTest(null))
+        assertFalse(CampaignMath.isAbTest(listOf("A")))
+        assertFalse(CampaignMath.isAbTest(listOf("A", "  ")))
+        assertTrue(CampaignMath.isAbTest(listOf("A", "B")))
+    }
+
+    @Test
+    fun pickWinner_byOpenThenClickRate() {
+        assertNull(CampaignMath.pickWinner(emptyList()))
+        // no signal
+        assertNull(
+            CampaignMath.pickWinner(
+                listOf(Triple("a", 0.0, 0.0), Triple("b", 0.0, 0.0)),
+            ),
+        )
+        assertEquals(
+            "b",
+            CampaignMath.pickWinner(
+                listOf(Triple("a", 0.2, 0.9), Triple("b", 0.4, 0.1)),
+            ),
+        )
+        // tie on opens -> higher clicks wins
+        assertEquals(
+            "b",
+            CampaignMath.pickWinner(
+                listOf(Triple("a", 0.3, 0.1), Triple("b", 0.3, 0.2)),
+            ),
+        )
+    }
+
+    // ── Merge-var extraction / validation ─────────────────────────────────────
+
+    @Test
+    fun extractTemplateVars_distinctSortedFromSubjectAndBody() {
+        assertEquals(
+            listOf("first_name", "offer"),
+            CampaignMath.extractTemplateVars("Hi {{ first_name }}", "Enjoy {{offer}}, {{ first_name }}!"),
+        )
+        assertEquals(emptyList<String>(), CampaignMath.extractTemplateVars(null, null))
+        assertEquals(emptyList<String>(), CampaignMath.extractTemplateVars("no vars here", ""))
+    }
+
+    @Test
+    fun missingTemplateVars_reportsUnfilled() {
+        val missing = CampaignMath.missingTemplateVars(
+            "Hi {{ first_name }}",
+            "Code {{ code }}",
+            mapOf("first_name" to "Sam", "code" to ""),
+        )
+        assertEquals(listOf("code"), missing)
+        assertTrue(
+            CampaignMath.isTemplateComplete(
+                "Hi {{ first_name }}",
+                "Code {{ code }}",
+                mapOf("first_name" to "Sam", "code" to "X1"),
+            ),
+        )
+    }
+
+    @Test
+    fun validateTemplateInput_enforcesFieldRules() {
+        assertEquals("A template name is required.", CampaignMath.validateTemplateInput("  ", "s", "b"))
+        assertEquals("A subject line is required.", CampaignMath.validateTemplateInput("n", "", "b"))
+        assertEquals("The email body cannot be empty.", CampaignMath.validateTemplateInput("n", "s", "   "))
+        assertNull(CampaignMath.validateTemplateInput("Welcome", "Hi {{name}}", "<p>Hello</p>"))
+        assertEquals(
+            "The template name is too long (max 120).",
+            CampaignMath.validateTemplateInput("x".repeat(121), "s", "b"),
+        )
+    }
+
+    @Test
+    fun validateCampaignInput_enforcesFieldRules() {
+        assertEquals("A campaign name is required.", CampaignMath.validateCampaignInput("", null, 0))
+        assertEquals("The budget cannot be negative.", CampaignMath.validateCampaignInput("n", null, -1))
+        assertNull(CampaignMath.validateCampaignInput("Spring Blast", "Awareness", 5000))
+        assertEquals(
+            "The campaign name is too long (max 200).",
+            CampaignMath.validateCampaignInput("x".repeat(201), null, 0),
+        )
+    }
+
+    // ── Budget parsing ────────────────────────────────────────────────────────
+
+    @Test
+    fun parseBudgetToCents_toleratesFormatting() {
+        assertEquals(0L, CampaignMath.parseBudgetToCents(""))
+        assertEquals(0L, CampaignMath.parseBudgetToCents(null))
+        assertEquals(1200L, CampaignMath.parseBudgetToCents("$12"))
+        assertEquals(123450L, CampaignMath.parseBudgetToCents("1,234.50"))
+        assertNull(CampaignMath.parseBudgetToCents("abc"))
+        assertNull(CampaignMath.parseBudgetToCents("-5"))
+    }
+
+    @Test
+    fun campaignTypes_coverAllServerVariants() {
+        assertEquals(listOf("email", "phone", "mail", "fax", "sms"), CampaignMath.CAMPAIGN_TYPES)
+    }
+}


### PR DESCRIPTION
## FE sweep SWP-141c - Android CRM campaigns depth

Deepens the Android CRM campaigns surface with a richer feature set:

- Campaign editor with template support
- Send flow wiring
- Reusable campaign templates
- Analytics readouts

Backed by a pure `CampaignMath` helper with unit-test coverage; repository, API, DTO and model layers extended and wired through navigation. All changes built and gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
