### PR TITLE
fix(agent-workers): default WorkerOut compute fields (500->200) + gitignore junk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ docs/suitecrm/testlogon/
 
 # In-place edit backups from parallel agent sessions
 *.bak_*
+.env.local.bak
+main==

--- a/app/models.py
+++ b/app/models.py
@@ -5901,12 +5901,12 @@ class WorkerOut(BaseModel):
     user_id: str
     label: str
     agent_type: str
-    tool: str
+    tool: str = ""
     tool_version: str = ""
-    compute_type: str
+    compute_type: str = ""
     compute_instance_id: str = ""
-    instance_type: str
-    llm_key_id: str
+    instance_type: str = ""
+    llm_key_id: str = ""
     llm_provider: str = ""
     host_id: str = ""
     # AQA-002: SSH key injected during provisioning, used by the agent QA exec


### PR DESCRIPTION
## fix(agent-workers): WorkerOut required-field 500 + junk cleanup

**Bug (found via live runtime probe):** `GET /ui/agent/workers` returned **500** for any account with pre-existing worker records. `WorkerOut` marked `tool`/`compute_type`/`instance_type`/`llm_key_id` as required, but workers created before those fields were added lack them → `WorkerListOut` response-model validation raised.

**Fix:** default the four fields to `""` (matching their already-defaulted siblings `tool_version`/`compute_instance_id`/`llm_provider`). Backward-compatible; new workers still populate them. Verified locally: `WorkerListOut` now serializes the legacy seed workers (500 → 200).

**chore:** gitignore dev-scratch junk (`.env.local.bak`, stray `main==`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
